### PR TITLE
fix: skip integration tests by default in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: ruff format --check src tests
 
       - name: Run tests
-        run: pytest tests/ -v --ignore=tests/integration --cov=src --cov-report=xml --cov-report=term-missing
+        run: pytest tests/ -v --ignore=tests/integration -m "not integration" --cov=src --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage report
         if: matrix.python-version == '3.13'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: .venv313/bin/python -m pytest tests/ -x -q --ignore=tests/integration
+        entry: .venv313/bin/python -m pytest tests/ -x -q --ignore=tests/integration -m "not integration"
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not integration'"
 markers = [
     "llamaparse: tests requiring LlamaParse API access",
     "integration: tests requiring real API keys",


### PR DESCRIPTION
## Summary
- Add `-m "not integration"` to pytest addopts in pyproject.toml
- Update pre-commit hook to explicitly skip integration tests  
- Update CI workflow to explicitly skip integration tests

Integration tests (marked with `@pytest.mark.integration`) will now be skipped by default in CI, pre-commit hooks, and local test runs.

To run integration tests locally, use:
```bash
pytest tests/ -m integration
```