### PR TITLE
docs: fix incorrect FFAzureClientBase inheritance documentation

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -85,7 +85,7 @@ Plico is a declarative context handling API wrapper for AI models with Excel-bas
 - `FFAIClientBase` - Abstract base class defining the contract
 - `FFLiteLLMClient` - Universal client supporting 100+ providers via LiteLLM (recommended)
 - `FFMistral`, `FFAnthropic`, `FFPerplexity`, etc. - Provider-specific implementations
-- `FFAzureClientBase` - Azure-specific base class (inherits from FFAIClientBase)
+- `FFAzureClientBase` - Azure-specific base class (implements FFAIClientBase interface, inherits from ABC)
 - `FFAzureLiteLLM` - Factory for creating Azure LiteLLM clients
 
 **Features:**

--- a/docs/architecture/CLIENTS_ARCHITECTURE.md
+++ b/docs/architecture/CLIENTS_ARCHITECTURE.md
@@ -16,24 +16,30 @@ The Client Wrappers subsystem provides a unified interface to multiple AI provid
 ```
                     FFAIClientBase (ABC)
                            │
-           ┌───────────────┼───────────────┐
-           │               │               │
-           ▼               ▼               ▼
-    ┌─────────────┐ ┌───────────┐ ┌─────────────┐
-    │  FFMistral  │ │FFAnthropic│ │FFOpenAI     │ ...
-    │FFMistralSmall│ │          │ │Assistant    │
-    └─────────────┘ └───────────┘ └─────────────┘
-           │
-           ▼
-    FFAzureClientBase (ABC)
-           │
-     ┌─────┴─────┬─────────────┬──────────────┐
-     │           │             │              │
-     ▼           ▼             ▼              ▼
-┌──────────┐┌──────────┐┌───────────┐┌────────────┐
-│FFAzure   ││FFAzure   ││FFAzure    ││FFAzurePhi  │
-│Mistral   ││Codestral ││DeepSeekV3 ││            │
-└──────────┘└──────────┘└───────────┘└────────────┘
+           ┌───────────────┼───────────────┬──────────────┐
+           │               │               │              │
+           ▼               ▼               ▼              ▼
+    ┌─────────────┐ ┌───────────┐ ┌─────────────┐ ┌──────────────┐
+    │  FFMistral  │ │FFAnthropic│ │ FFGemini    │ │FFNvidiaDeepSeek│
+    │FFMistralSmall│ │FFAnthropic│ │FFPerplexity │ │FFOpenAIAssistant│
+    └─────────────┘ │  Cached   │ └─────────────┘ └──────────────┘
+                    └───────────┘
+    ┌─────────────────┐
+    │ FFLiteLLMClient │
+    │ (Universal)     │
+    └─────────────────┘
+
+                    FFAzureClientBase (ABC)
+                    [Implements FFAIClientBase interface]
+                           │
+     ┌───────┬───────┬─────┴─────┬───────────┬────────────┬──────────┐
+     │       │       │           │           │            │          │
+     ▼       ▼       ▼           ▼           ▼            ▼          ▼
+ ┌───────┐┌───────┐┌───────┐┌──────────┐┌───────────┐┌─────────┐┌──────┐
+ │FFAzure││FFAzure││FFAzure││FFAzure   ││FFAzure    ││FFAzure  ││FFAzure│
+ │Mistral││Mistral││Code-  ││DeepSeek  ││DeepSeekV3 ││MSDeep   ││Phi   │
+ │       ││Small  ││stral  ││          ││           ││SeekR1   ││      │
+ └───────┘└───────┘└───────┘└──────────┘└───────────┘└─────────┘└──────┘
 ```
 
 ## FFAIClientBase Contract
@@ -191,10 +197,10 @@ client = create_azure_client(
 
 ## FFAzureClientBase Design
 
-Azure clients share significant common code. `FFAzureClientBase` is an ABC that inherits from `FFAIClientBase` and provides:
+Azure clients share significant common code. `FFAzureClientBase` is an ABC that inherits directly from `ABC` (not `FFAIClientBase`) but implements the same interface contract:
 
 ```python
-class FFAzureClientBase(FFAIClientBase):
+class FFAzureClientBase(ABC):
     """Base class for Azure AI Inference clients."""
 
     # Abstract properties for configuration
@@ -218,10 +224,15 @@ class FFAzureClientBase(FFAIClientBase):
     @abstractmethod
     def _env_key_prefix(self) -> str: pass  # e.g., "AZURE_MISTRAL"
 
-    # Common implementation
+    # Common implementation (implements FFAIClientBase interface)
     def generate_response(self, prompt, **kwargs) -> str:
         # Full implementation shared by all Azure clients
         ...
+
+    def clear_conversation(self) -> None: ...
+    def get_conversation_history(self) -> list: ...
+    def set_conversation_history(self, history: list) -> None: ...
+    # Note: clone() not implemented - Azure clients have their own parallel execution strategy
 ```
 
 ### Concrete Azure Client Example


### PR DESCRIPTION
- FFAzureClientBase inherits from ABC directly, not FFAIClientBase
- Updated class hierarchy diagram to show separate hierarchies
- Added all 7 Azure clients to diagram (was only 4)
- Added FFLiteLLMClient, FFGemini, FFPerplexity, FFNvidiaDeepSeek, FFOpenAIAssistant to diagram
- Noted that FFAzureClientBase implements interface but lacks clone()