### PR TITLE
fix: replace | with @ in parquet filenames for Windows compatibility

### DIFF
--- a/src/orchestrator/document_processor.py
+++ b/src/orchestrator/document_processor.py
@@ -117,7 +117,7 @@ class DocumentProcessor:
         Format: {checksum_prefix}|{sanitized_base_name}.parquet
         """
         safe_name = self._sanitize_name(base_name)
-        filename = f"{self.get_checksum_prefix(checksum)}|{safe_name}.parquet"
+        filename = f"{self.get_checksum_prefix(checksum)}@{safe_name}.parquet"
         return self.cache_dir / filename
 
     def _sanitize_name(self, name: str) -> str:

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -104,7 +104,7 @@ class TestGetParquetPath:
         path = processor.get_parquet_path(checksum, base_name)
 
         assert str(path).startswith(temp_cache_dir)
-        assert "a1b2c3d4|My_Document.parquet" in str(path)
+        assert "a1b2c3d4@My_Document.parquet" in str(path)
 
     def test_get_parquet_path_sanitizes_name(self, processor):
         checksum = "a1b2c3d4" + "0" * 56

--- a/tests/test_document_registry.py
+++ b/tests/test_document_registry.py
@@ -89,10 +89,16 @@ class TestDocumentRegistryInit:
 
 class TestResolvePath:
     def test_resolve_path_absolute(self, registry):
-        abs_path = "/absolute/path/to/file.txt"
+        import platform
+
+        if platform.system() == "Windows":
+            abs_path = "C:\\absolute\\path\\to\\file.txt"
+        else:
+            abs_path = "/absolute/path/to/file.txt"
 
         result = registry.resolve_path(abs_path)
 
+        assert os.path.isabs(result)
         assert result == abs_path
 
     def test_resolve_path_relative(self, registry, fixtures_dir):


### PR DESCRIPTION
## Summary
- Replace `|` with `@` as separator in parquet cache filenames (`|` is a reserved character on Windows causing OSError 123)
- Update `test_resolve_path_absolute` to use platform-appropriate absolute paths (fixes assertion failure on Windows)

## Test Results
All 46 tests pass on Windows after the fix.