### PR TITLE
fix: optimize document processing and clean up orphaned cache files

### DIFF
--- a/src/orchestrator/document_processor.py
+++ b/src/orchestrator/document_processor.py
@@ -125,7 +125,36 @@ class DocumentProcessor:
         name = Path(name).stem
         return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
 
-    def needs_parsing(self, file_path: str, reference_name: str) -> bool:
+    def _cleanup_old_parquet_files(self, reference_name: str, keep_checksum: str) -> int:
+        """Remove old parquet files for a reference_name that don't match current checksum.
+
+        Args:
+            reference_name: Reference name to clean up
+            keep_checksum: Checksum prefix of the file to keep
+
+        Returns:
+            Number of files removed
+
+        """
+        safe_name = self._sanitize_name(reference_name)
+        pattern = f"*@{safe_name}.parquet"
+        removed = 0
+
+        for old_file in self.cache_dir.glob(pattern):
+            old_prefix = old_file.stem.split("@")[0]
+            if old_prefix != keep_checksum:
+                old_file.unlink()
+                removed += 1
+                logger.debug(f"Removed orphaned cache file: {old_file.name}")
+
+        if removed > 0:
+            logger.info(f"Cleaned up {removed} orphaned cache file(s) for {reference_name}")
+
+        return removed
+
+    def needs_parsing(
+        self, file_path: str, reference_name: str, checksum: str | None = None
+    ) -> bool:
         """Check if a document needs to be (re)parsed.
 
         Returns True if:
@@ -135,6 +164,7 @@ class DocumentProcessor:
         Args:
             file_path: Path to source document
             reference_name: Reference name to look up in parquet
+            checksum: Pre-computed checksum (optional, computed if not provided)
 
         Returns:
             True if document needs parsing, False if cached version is valid
@@ -143,7 +173,7 @@ class DocumentProcessor:
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"Document not found: {file_path}")
 
-        current_checksum = self.compute_checksum(file_path)
+        current_checksum = checksum or self.compute_checksum(file_path)
         parquet_path = self.get_parquet_path(current_checksum, reference_name)
 
         if not parquet_path.exists():
@@ -242,23 +272,34 @@ class DocumentProcessor:
             ) from e
 
     def store_document(
-        self, file_path: str, reference_name: str, common_name: str, content: str
+        self,
+        file_path: str,
+        reference_name: str,
+        common_name: str,
+        content: str,
+        checksum: str | None = None,
     ) -> str:
         """Store parsed document content as a parquet file.
+
+        Cleans up old parquet files with different checksums before storing.
 
         Args:
             file_path: Original file path
             reference_name: Reference name for the document
             common_name: Human-readable name
             content: Parsed content (markdown)
+            checksum: Pre-computed checksum (optional, computed if not provided)
 
         Returns:
             Path to the created parquet file
 
         """
-        checksum = self.compute_checksum(file_path)
+        checksum = checksum or self.compute_checksum(file_path)
         file_size = os.path.getsize(file_path)
         parquet_path = self.get_parquet_path(checksum, reference_name)
+
+        checksum_prefix = self.get_checksum_prefix(checksum)
+        self._cleanup_old_parquet_files(reference_name, checksum_prefix)
 
         df = pl.DataFrame(
             {
@@ -372,14 +413,14 @@ class DocumentProcessor:
         checksum = self.compute_checksum(file_path)
         parquet_path = self.get_parquet_path(checksum, reference_name)
 
-        if not self.needs_parsing(file_path, reference_name):
+        if not self.needs_parsing(file_path, reference_name, checksum=checksum):
             logger.info(f"Using cached document: {reference_name}")
             doc_data = self.load_document(str(parquet_path))
             return doc_data["content"]
 
         logger.info(f"Parsing document: {reference_name}")
         content = self.parse_document(file_path)
-        self.store_document(file_path, reference_name, common_name, content)
+        self.store_document(file_path, reference_name, common_name, content, checksum=checksum)
 
         return content
 

--- a/src/orchestrator/workbook_parser.py
+++ b/src/orchestrator/workbook_parser.py
@@ -102,6 +102,8 @@ class WorkbookParser:
         "reference_name",
         "common_name",
         "file_path",
+        "tags",
+        "chunking_strategy",
         "notes",
     ]
     CLIENTS_HEADERS = [

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -139,6 +139,101 @@ class TestNeedsParsing:
         with pytest.raises(FileNotFoundError):
             processor.needs_parsing(str(missing_file), "missing")
 
+    def test_needs_parsing_with_precomputed_checksum(self, processor, fixtures_dir):
+        file_path = fixtures_dir / "client_info.txt"
+        checksum = processor.compute_checksum(str(file_path))
+
+        result = processor.needs_parsing(str(file_path), "new_doc", checksum=checksum)
+
+        assert result is True
+
+    def test_needs_parsing_uses_precomputed_checksum(self, processor, fixtures_dir):
+        file_path = fixtures_dir / "client_info.txt"
+        content = "test content"
+        processor.store_document(str(file_path), "cached_doc", "Cached Doc", content)
+
+        checksum = processor.compute_checksum(str(file_path))
+        result = processor.needs_parsing(str(file_path), "cached_doc", checksum=checksum)
+
+        assert result is False
+
+
+class TestCleanupOldParquetFiles:
+    def test_cleanup_removes_old_parquet_files(self, processor, fixtures_dir, temp_cache_dir):
+        file_path = fixtures_dir / "client_info.txt"
+        reference_name = "test_doc"
+
+        old_checksum = "aaaaaaaa" + "0" * 56
+        old_parquet_path = processor.get_parquet_path(old_checksum, reference_name)
+        old_parquet_path.write_bytes(b"old parquet data")
+
+        content = "test content"
+        new_parquet_path = processor.store_document(
+            str(file_path), reference_name, "Test Doc", content
+        )
+
+        assert not old_parquet_path.exists()
+        assert Path(new_parquet_path).exists()
+
+    def test_cleanup_preserves_matching_checksum(self, processor, fixtures_dir, temp_cache_dir):
+        file_path = fixtures_dir / "client_info.txt"
+        reference_name = "test_doc"
+        content = "test content"
+
+        parquet_path = processor.store_document(str(file_path), reference_name, "Test Doc", content)
+
+        cache_files_before = list(Path(temp_cache_dir).glob("*.parquet"))
+        assert len(cache_files_before) == 1
+
+        processor._cleanup_old_parquet_files(
+            reference_name,
+            processor.get_checksum_prefix(processor.compute_checksum(str(file_path))),
+        )
+
+        cache_files_after = list(Path(temp_cache_dir).glob("*.parquet"))
+        assert len(cache_files_after) == 1
+        assert cache_files_after[0] == Path(parquet_path)
+
+    def test_cleanup_does_not_affect_other_documents(self, processor, fixtures_dir, temp_cache_dir):
+        file1 = fixtures_dir / "client_info.txt"
+        file2 = fixtures_dir / "spec_doc.md"
+
+        old_checksum = "aaaaaaaa" + "0" * 56
+        old_parquet_path = processor.get_parquet_path(old_checksum, "other_doc")
+        old_parquet_path.write_bytes(b"old parquet data")
+
+        processor.store_document(str(file1), "doc1", "Doc 1", "content1")
+        processor.store_document(str(file2), "doc2", "Doc 2", "content2")
+
+        cache_files = list(Path(temp_cache_dir).glob("*.parquet"))
+        assert len(cache_files) == 3
+        assert old_parquet_path.exists()
+
+        doc1_files = list(Path(temp_cache_dir).glob("*@doc1.parquet"))
+        doc2_files = list(Path(temp_cache_dir).glob("*@doc2.parquet"))
+        other_files = list(Path(temp_cache_dir).glob("*@other_doc.parquet"))
+        assert len(doc1_files) == 1
+        assert len(doc2_files) == 1
+        assert len(other_files) == 1
+
+    def test_cleanup_handles_multiple_old_versions(self, processor, fixtures_dir, temp_cache_dir):
+        file_path = fixtures_dir / "client_info.txt"
+        reference_name = "multi_version_doc"
+
+        for i in range(3):
+            old_checksum = chr(ord("a") + i) * 8 + "0" * 56
+            old_parquet_path = processor.get_parquet_path(old_checksum, reference_name)
+            old_parquet_path.write_bytes(f"old version {i}".encode())
+
+        cache_files_before = list(Path(temp_cache_dir).glob("*.parquet"))
+        assert len(cache_files_before) == 3
+
+        content = "new content"
+        processor.store_document(str(file_path), reference_name, "Multi Doc", content)
+
+        cache_files_after = list(Path(temp_cache_dir).glob("*@multi_version_doc.parquet"))
+        assert len(cache_files_after) == 1
+
 
 class TestParseDocument:
     def test_parse_text_file_directly(self, processor, fixtures_dir):


### PR DESCRIPTION
## Summary

- **Orphaned cache cleanup**: Added `_cleanup_old_parquet_files()` to remove stale parquet cache files when documents change, preventing disk space accumulation over time
- **Checksum optimization**: Added optional `checksum` parameter to `needs_parsing()` and `store_document()` to avoid redundant SHA256 computations (reduced from 3x to 1x per document access)
- **Template columns**: Added `tags` and `chunking_strategy` columns to `DOCUMENTS_HEADERS` for complete workbook templates

## Changes

| File | Change |
|------|--------|
| `src/orchestrator/document_processor.py` | Added orphan cleanup, checksum optimization |
| `src/orchestrator/workbook_parser.py` | Added missing template columns |
| `tests/test_document_processor.py` | Added 6 new tests |

## Test Results

- All 29 tests pass (1 skipped for PDF parsing)
- Verified with `inv documents` workflow (23 prompts, 236 chunks indexed)

## Flow Comparison

**Before:** Checksum computed 3x per document access
**After:** Checksum computed 1x per document access