### PR TITLE
refactor: generalize discovery params from resumes_path/jd_path to documents_path/shared_document_path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -665,30 +665,43 @@ Auto-discover resumes from a folder and evaluate against a job description.
 
 ### CLI Integration
 
-**Create a workbook from a folder:**
+**Create a self-contained workbook (JD + resumes baked in):**
 
 ```bash
 python scripts/create_screening_workbook.py ./screening.xlsx \
     --resumes-path ./resumes/ --jd ./job_description.md
-
-# With planning phase (auto-derive scoring from JD)
-python scripts/create_screening_workbook.py ./screening.xlsx \
-    --resumes-path ./resumes/ --jd ./jd.md --planning
 ```
 
-**Runtime injection (no workbook modification):**
+**Create a template workbook (reusable across requisitions):**
 
 ```bash
-python scripts/run_orchestrator.py ./prompts.xlsx \
-    --resumes-path ./resumes/ --jd ./jd.md -c 1
+# JD baked in, resumes injected at runtime
+python scripts/create_screening_workbook.py ./template.xlsx \
+    --jd ./job_description.md
+
+# Generic template (nothing baked in)
+python scripts/create_screening_workbook.py ./template.xlsx
+```
+
+**Runtime injection (use template with different data):**
+
+```bash
+# Template with JD baked in
+python scripts/run_orchestrator.py ./template.xlsx \
+    --documents-path ./resumes/ -c 1
+
+# Generic template
+python scripts/run_orchestrator.py ./template.xlsx \
+    --shared-document ./jd.md --shared-document-name job_description \
+    --documents-path ./resumes/ -c 1
 ```
 
 **Invoke tasks:**
 
 ```bash
-inv screening.run -r ./resumes/ -j ./jd.md
-inv screening.manifest -r ./resumes/ -j ./jd.md          # Manifest-first (no Excel)
-inv screening.create -r ./resumes/ -j ./jd.md --planning
+inv screening.run --resumes-path ./resumes/ --jd ./jd.md
+inv screening.manifest --resumes-path ./resumes/ --jd ./jd.md
+inv screening.create --jd ./jd.md --output ./template.xlsx
 inv screening.inspect ./screening.xlsx
 ```
 
@@ -698,8 +711,8 @@ inv screening.inspect ./screening.xlsx
 orchestrator = ExcelOrchestrator(
     workbook_path="screening.xlsx",
     client=client,
-    resumes_path="./resumes/",      # Auto-discover documents
-    jd_path="./job_description.md", # Shared JD as "job_description"
+    documents_path="./resumes/",          # Auto-discover documents
+    shared_document_path="./jd.md",      # Shared document (name derived from filename)
 )
 orchestrator.run()
 ```
@@ -710,8 +723,8 @@ orchestrator.run()
 orchestrator = ManifestOrchestrator(
     manifest_dir="./manifests/manifest_screening",
     client=client,
-    resumes_path="./resumes/",      # Auto-discover documents
-    jd_path="./job_description.md", # Shared JD as "job_description"
+    documents_path="./resumes/",          # Auto-discover documents
+    shared_document_path="./jd.md",      # Shared document (name derived from filename)
 )
 orchestrator.run()
 ```

--- a/MANIFEST_README.md
+++ b/MANIFEST_README.md
@@ -145,8 +145,8 @@ orchestrator = ManifestOrchestrator(
     manifest_dir="./manifests/manifest_my_workflow",
     client=client,
     concurrency=4,
-    resumes_path="./resumes/",       # Auto-discover documents
-    jd_path="./job_description.md",  # Shared JD as "job_description"
+    documents_path="./resumes/",          # Auto-discover documents
+    shared_document_path="./job_description.md",  # Shared document (name derived from filename)
 )
 parquet_path = orchestrator.run()
 
@@ -1423,8 +1423,8 @@ orchestrator = ManifestOrchestrator(
     manifest_dir="./manifests/manifest_name",
     client=client,
     concurrency=4,
-    resumes_path="./resumes/",       # Auto-discover documents
-    jd_path="./job_description.md",  # Shared JD as "job_description"
+    documents_path="./resumes/",          # Auto-discover documents
+    shared_document_path="./job_description.md",  # Shared document (name derived from filename)
 )
 parquet_path = orchestrator.run()
 ```

--- a/README.md
+++ b/README.md
@@ -945,8 +945,8 @@ orchestrator = ManifestOrchestrator(
     manifest_dir="./manifests/my_workflow/",
     client=client,
     concurrency=4,
-    resumes_path="./resumes/",       # Auto-discover documents
-    jd_path="./job_description.md",  # Shared JD as "job_description"
+    documents_path="./resumes/",          # Auto-discover documents
+    shared_document_path="./job_description.md",  # Shared document (name derived from filename)
 )
 parquet_path = orchestrator.run()
 

--- a/USE_CASES/resume_screening.md
+++ b/USE_CASES/resume_screening.md
@@ -24,69 +24,101 @@ That's it. Two arguments: a folder and a file.
 
 ---
 
+## Creation Modes
+
+Both creation scripts support optional `--resumes-path` and `--jd` arguments,
+giving you control over what gets baked in vs injected at runtime.
+
+### Workbook Modes
+
+| Mode | JD | Resumes | Creation | Runtime |
+|------|----|---------|----------|---------|
+| **Self-contained** | `--jd` | `--resumes-path` | `create_screening_workbook.py ./out.xlsx --jd ./jd.md --resumes-path ./resumes/` | `run_orchestrator.py ./out.xlsx` |
+| **Template (JD baked)** | `--jd` | *(omit)* | `create_screening_workbook.py ./template.xlsx --jd ./jd.md` | `run_orchestrator.py ./template.xlsx --documents-path ./resumes/` |
+| **Template (generic)** | *(omit)* | *(omit)* | `create_screening_workbook.py ./template.xlsx` | `run_orchestrator.py ./template.xlsx --shared-document ./jd.md --shared-document-name job_description --documents-path ./resumes/` |
+
+### Manifest Modes
+
+| Mode | JD | Resumes | Creation | Runtime |
+|------|----|---------|----------|---------|
+| **Template (JD baked)** | `--jd` | *(omit)* | `create_screening_manifest.py --jd ./jd.md` | `manifest_run.py ./manifest_screening --documents-path ./resumes/` |
+| **Template (generic)** | *(omit)* | *(omit)* | `create_screening_manifest.py` | `manifest_run.py ./manifest_screening --shared-document ./jd.md --shared-document-name job_description --documents-path ./resumes/` |
+
+`--resumes-path` on the manifest script is optional and used only for sizing
+the synthesis `top_n` count. Resumes are always injected at runtime.
+
+---
+
 ## Three Approaches
 
-### Approach 1: Create a Workbook, Then Run (Excel)
+### Approach 1: Self-Contained Workbook (Excel)
 
-Creates a `.xlsx` workbook you can inspect, edit prompts, and re-run.
+Creates a `.xlsx` workbook with all documents and batch data baked in.
 
 ```bash
-# Create the workbook
+# Create the workbook (JD + resumes baked in)
 python scripts/create_screening_workbook.py ./screening.xlsx \
     --resumes-path ./resumes/ \
     --jd ./job_description.md
 
-# Run the orchestrator
+# Run the orchestrator (no flags needed)
 python scripts/run_orchestrator.py ./screening.xlsx -c 1
 ```
 
-**Why this approach:** You can open the `.xlsx`, tweak prompts, adjust scoring
-weights, or add synthesis prompts before running. Results are written back
-into the workbook.
+**Why this approach:** Self-contained file you can share, email, or version.
+Results are written back into the workbook.
 
-### Approach 2: Create a Manifest, Then Run (YAML)
+### Approach 2: Template Workbook (Excel)
 
-Creates a manifest folder (YAML files) directly — no Excel needed. Documents
-and batch data are injected at runtime via `--resumes-path` and `--jd`.
+Creates a `.xlsx` workbook with prompts and scoring but no baked-in data.
+Reusable across different JDs and resume folders.
 
 ```bash
-# Create the manifest (YAML only — no baked-in data/documents)
-python scripts/create_screening_manifest.py ./manifests/manifest_screening \
-    --resumes-path ./resumes/ \
+# Template with JD baked in
+python scripts/create_screening_workbook.py ./template.xlsx \
     --jd ./job_description.md
 
-# Run the manifest orchestrator with runtime injection
+# Run with resumes injected at runtime
+python scripts/run_orchestrator.py ./template.xlsx \
+    --documents-path ./resumes/ -c 1
+
+# Generic template (nothing baked in)
+python scripts/create_screening_workbook.py ./template.xlsx
+
+python scripts/run_orchestrator.py ./template.xlsx \
+    --shared-document ./jd.md --shared-document-name job_description \
+    --documents-path ./resumes/ -c 2
+```
+
+**Why this approach:** Edit prompts once in the template, screen different
+requisitions by swapping `--documents-path` and `--shared-document` at runtime.
+
+### Approach 3: Template Manifest (YAML)
+
+Creates a manifest folder (YAML files) directly — no Excel needed. The JD
+can optionally be baked into `documents.yaml`; resumes are always injected
+at runtime.
+
+```bash
+# Template with JD baked in
+python scripts/create_screening_manifest.py ./manifests/manifest_screening \
+    --jd ./job_description.md
+
+# Run with resumes injected at runtime
 python scripts/manifest_run.py ./manifests/manifest_screening \
-    --resumes-path ./resumes/ \
-    --jd ./job_description.md \
-    -c 1
+    --documents-path ./resumes/ -c 1
+
+# Generic template (nothing baked in)
+python scripts/create_screening_manifest.py ./manifests/manifest_screening
+
+python scripts/manifest_run.py ./manifests/manifest_screening \
+    --shared-document ./jd.md --shared-document-name job_description \
+    --documents-path ./resumes/ -c 1
 ```
 
 **Why this approach:** Manifests are Git-friendly, AI-composable, and the
-canonical workflow representation. Documents are injected at runtime so the
-same manifest can screen different resume folders. Results go to parquet.
-
-### Approach 3: Runtime Injection (No Workbook/Manifest Modification)
-
-Run the orchestrator with `--resumes-path` and `--jd` flags. Documents and
-batch data are injected at runtime without modifying the workbook or manifest.
-
-```bash
-# Excel path
-python scripts/run_orchestrator.py ./my_prompts.xlsx \
-    --resumes-path ./resumes/ \
-    --jd ./job_description.md \
-    -c 2
-
-# Manifest path
-python scripts/manifest_run.py ./manifests/manifest_screening \
-    --resumes-path ./resumes/ \
-    --jd ./job_description.md \
-    -c 2
-```
-
-**Why this approach:** You maintain a single reusable workbook or manifest
-and swap out the resume folder per requisition.
+canonical workflow representation. Prompts, scoring, and synthesis travel in
+version control; data stays on disk. Results go to parquet.
 
 ---
 
@@ -138,7 +170,7 @@ python scripts/create_screening_workbook.py ./screening.xlsx \
 
 ### `create_screening_workbook.py`
 
-Creates a complete `.xlsx` workbook from a folder of resumes.
+Creates a `.xlsx` workbook with prompts, scoring, and synthesis sheets.
 
 ```bash
 python scripts/create_screening_workbook.py <output_path> [options]
@@ -147,8 +179,8 @@ python scripts/create_screening_workbook.py <output_path> [options]
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `output` | Yes | — | Output `.xlsx` path |
-| `--resumes-path` | Yes | — | Folder containing resume documents |
-| `--jd` | Yes | — | Path to job description file |
+| `--resumes-path` | No | — | Folder containing resume documents (baked in if provided) |
+| `--jd` | No | — | Path to job description file (baked in if provided) |
 | `--planning` | No | off | Auto-derive scoring from JD via LLM |
 | `--extensions` | No | `.pdf .docx .doc .txt .md` | File extensions to include |
 | `--client` | No | config default | Client type from `config/clients.yaml` |
@@ -159,7 +191,7 @@ python scripts/create_screening_workbook.py <output_path> [options]
 **Examples:**
 
 ```bash
-# Basic static scoring
+# Self-contained (JD + resumes baked in)
 python scripts/create_screening_workbook.py ./screening.xlsx \
     --resumes-path ./resumes/ --jd ./jd.md
 
@@ -167,22 +199,18 @@ python scripts/create_screening_workbook.py ./screening.xlsx \
 python scripts/create_screening_workbook.py ./screening.xlsx \
     --resumes-path ./resumes/ --jd ./jd.md --planning
 
-# Only PDF and DOCX files, with Anthropic
-python scripts/create_screening_workbook.py ./screening.xlsx \
-    --resumes-path ./resumes/ --jd ./jd.md \
-    --extensions .pdf .docx --client anthropic
+# Template with JD baked in (resumes injected at runtime)
+python scripts/create_screening_workbook.py ./template.xlsx \
+    --jd ./jd.md
 
-# Custom system instructions
-python scripts/create_screening_workbook.py ./screening.xlsx \
-    --resumes-path ./resumes/ --jd ./jd.md \
-    --system-instructions "You are a senior technical recruiter for a fintech company."
+# Generic template (nothing baked in)
+python scripts/create_screening_workbook.py ./template.xlsx
 ```
 
 ### `create_screening_manifest.py`
 
-Creates a manifest folder (YAML files) directly from a folder of resumes.
-No Excel intermediary. Documents and batch data are injected at runtime
-via `manifest_run.py --resumes-path` and `--jd`.
+Creates a manifest folder (YAML files) directly. The JD can optionally be
+baked into `documents.yaml`; resumes are always injected at runtime.
 
 ```bash
 python scripts/create_screening_manifest.py [output_dir] [options]
@@ -191,8 +219,8 @@ python scripts/create_screening_manifest.py [output_dir] [options]
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `output` | No | `./manifests/manifest_screening` | Output manifest directory |
-| `--resumes-path` | Yes | — | Folder containing resume documents |
-| `--jd` | Yes | — | Path to job description file |
+| `--resumes-path` | No | — | Folder for top_n sizing (not baked in) |
+| `--jd` | No | — | Path to JD file (baked into `documents.yaml` if provided) |
 | `--planning` | No | off | Auto-derive scoring from JD via LLM |
 | `--extensions` | No | `.pdf .docx .doc .txt .md` | File extensions to include |
 | `--client` | No | config default | Client type from `config/clients.yaml` |
@@ -203,23 +231,22 @@ python scripts/create_screening_manifest.py [output_dir] [options]
 **Examples:**
 
 ```bash
-# Basic static scoring
+# Template with JD baked in
 python scripts/create_screening_manifest.py \
-    --resumes-path ./resumes/ --jd ./jd.md
+    --jd ./job_description.md
 
-# Custom output directory and planning mode
+# Generic template (nothing baked in)
+python scripts/create_screening_manifest.py
+
+# Planning mode with JD and resume count for top_n sizing
 python scripts/create_screening_manifest.py ./manifests/my_screening \
-    --resumes-path ./resumes/ --jd ./jd.md --planning
+    --jd ./jd.md --planning --resumes-path ./resumes/
 ```
-
-**Note:** This script validates that resumes are discovered and the JD exists,
-but does *not* bake documents or batch data into the manifest. They are
-injected at runtime via `manifest_run.py --resumes-path` and `--jd`.
 
 ### `run_orchestrator.py` (with discovery flags)
 
-Runs the orchestrator. When `--resumes-path` and/or `--jd` are provided,
-documents and batch data are injected at runtime.
+Runs the orchestrator. When `--documents-path` and/or `--shared-document` are
+provided, documents and batch data are injected at runtime.
 
 ```bash
 python scripts/run_orchestrator.py <workbook> [options]
@@ -228,8 +255,9 @@ python scripts/run_orchestrator.py <workbook> [options]
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `workbook` | Yes | — | Path to `.xlsx` workbook |
-| `--resumes-path` | No | — | Auto-discover documents from folder |
-| `--jd` | No | — | Job description file (shared doc) |
+| `--documents-path` | No | — | Auto-discover documents from folder |
+| `--shared-document` | No | — | Shared document file (e.g., job description) |
+| `--shared-document-name` | No | — | Explicit reference name for the shared document |
 | `--client` | No | config default | Client type override |
 | `--concurrency` / `-c` | No | 2 | Max concurrent API calls |
 | `--dry-run` | No | off | Validate without executing |
@@ -244,7 +272,8 @@ python scripts/run_orchestrator.py ./screening.xlsx -c 1
 
 # With runtime injection (no workbook modification)
 python scripts/run_orchestrator.py ./screening.xlsx \
-    --resumes-path ./resumes/ --jd ./jd.md -c 2
+    --documents-path ./resumes/ --shared-document ./jd.md \
+    --shared-document-name job_description -c 2
 
 # Dry run to validate before executing
 python scripts/run_orchestrator.py ./screening.xlsx --dry-run
@@ -255,8 +284,9 @@ python scripts/run_orchestrator.py ./screening.xlsx --quiet
 
 ### `manifest_run.py` (with discovery flags)
 
-Runs the manifest orchestrator. When `--resumes-path` and/or `--jd` are
-provided, documents and batch data are injected at runtime.
+Runs the manifest orchestrator. When `--documents-path` and/or
+`--shared-document` are provided, documents and batch data are injected at
+runtime.
 
 ```bash
 python scripts/manifest_run.py <manifest_dir> [options]
@@ -265,8 +295,9 @@ python scripts/manifest_run.py <manifest_dir> [options]
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `manifest_dir` | Yes | — | Path to manifest folder |
-| `--resumes-path` | No | — | Auto-discover documents from folder |
-| `--jd` | No | — | Job description file (shared doc) |
+| `--documents-path` | No | — | Auto-discover documents from folder |
+| `--shared-document` | No | — | Shared document file (e.g., job description) |
+| `--shared-document-name` | No | — | Explicit reference name for the shared document |
 | `--client` | No | config default | Client type override |
 | `--concurrency` / `-c` | No | 2 | Max concurrent API calls |
 | `--dry-run` | No | off | Validate without executing |
@@ -280,7 +311,8 @@ python scripts/manifest_run.py ./manifests/manifest_screening -c 1
 
 # With runtime injection (no manifest modification)
 python scripts/manifest_run.py ./manifests/manifest_screening \
-    --resumes-path ./resumes/ --jd ./jd.md -c 2
+    --documents-path ./resumes/ --shared-document ./jd.md \
+    --shared-document-name job_description -c 2
 
 # Dry run to validate before executing
 python scripts/manifest_run.py ./manifests/manifest_screening --dry-run
@@ -433,42 +465,46 @@ resumes/               job_descriptions/
   alice_chen.md          senior_engineer.md
   bob_martinez.pdf
   carol_okafor.docx
-       │                      │
-       v                      v
-  discover_documents()   _resolve_jd_document()
-       │                      │
-       │  reference_name      │  reference_name
-       │  common_name         │  "job_description"
-       │  file_path           │  file_path (absolute)
-       │  tags=["resume"]     │  tags="jd"
-       │                      │
-       v                      v
-  create_data_rows_        Shared doc
-  from_documents()         (available to all
-  (one row per resume       prompts, not bound
-   with _documents          to any data row)
-   column binding)                │
-       │                          │
-        v                          v
-   ┌──────────────────────────────────────────────────────┐
-   │  OrchestratorBase._inject_discovery_overrides()       │
-   │                                                        │
-   │  1. Load workbook sheets OR manifest YAML files        │
-   │  2. If resumes_path: discover & inject docs + data    │
-   │  3. If jd_path: inject as shared doc                  │
-   │  4. Merge with any source docs                        │
-   │  5. Run validation + execution                        │
-   └──────────────────────────────────────────────────────┘
+        │                      │
+        v                      v
+   discover_documents()   _resolve_shared_document()
+        │                      │
+        │  reference_name      │  reference_name (derived
+        │  common_name         │    from filename stem,
+        │  file_path           │    e.g. "senior_engineer")
+        │                      │  file_path (absolute)
+        │                      │  tags="shared"
+        │                      │
+        v                      v
+   create_data_rows_        Shared doc
+   from_documents()         (available to all
+   (one row per resume       prompts, not bound
+    with _documents          to any data row)
+    column binding)                │
+        │                          │
+         v                          v
+    ┌──────────────────────────────────────────────────────┐
+    │  OrchestratorBase._inject_discovery_overrides()       │
+    │                                                        │
+    │  1. Load workbook sheets OR manifest YAML files        │
+    │  2. If documents_path: discover & inject docs + data   │
+    │  3. If shared_document_path: inject as shared doc      │
+    │  4. Merge with any source docs                        │
+    │  5. Run validation + execution                        │
+    └──────────────────────────────────────────────────────┘
 
-   Shared by both ExcelOrchestrator and ManifestOrchestrator.
+    Shared by both ExcelOrchestrator and ManifestOrchestrator.
 ```
 
 Key points:
 
-- `--jd` creates a document with `reference_name="job_description"`. Reference
-  it in prompts via `references: '["job_description"]'`.
-- `--resumes-path` creates one data row per discovered file. Each row binds
-  its document via the `_documents` column.
+- `--shared-document` creates a document with a `reference_name` derived
+  from the filename (e.g., `senior_engineer.md` → `senior_engineer`).
+  Use `--shared-document-name` to override (e.g., `--shared-document-name
+  job_description` ensures the name matches prompts that reference
+  `["job_description"]`).
+- `--documents-path` creates one data row per discovered file. Each row
+  binds its document via the `_documents` column.
 - Paths are stored as absolute for runtime injection, relative for workbook
   creation.
 - Discovery merges with existing workbook documents/data if present.

--- a/docs/ORCHESTRATOR README.md
+++ b/docs/ORCHESTRATOR README.md
@@ -703,7 +703,7 @@ The discovery module auto-discovers documents from a folder and bootstraps evalu
 
 ### Runtime Injection
 
-Pass `resumes_path` and `jd_path` to the orchestrator for automatic document discovery:
+Pass `documents_path` and `shared_document_path` to the orchestrator for automatic document discovery:
 
 ```python
 from src.orchestrator import ExcelOrchestrator
@@ -713,8 +713,8 @@ client = FFMistralSmall(api_key="...")
 orchestrator = ExcelOrchestrator(
     workbook_path="screening.xlsx",
     client=client,
-    resumes_path="./resumes/",       # Auto-discover documents
-    jd_path="./job_description.md",  # Shared JD as "job_description"
+    documents_path="./resumes/",          # Auto-discover documents
+    shared_document_path="./jd.md",      # Shared document (name derived from filename)
 )
 orchestrator.run()
 ```
@@ -742,7 +742,7 @@ from src.orchestrator.discovery import discover_documents, create_data_rows_from
 
 docs = discover_documents("./resumes/")
 data_rows = create_data_rows_from_documents(docs)
-create_evaluation_workbook("screening.xlsx", "./resumes/", jd_path="./jd.md")
+create_evaluation_workbook("screening.xlsx", "./resumes/", shared_documents=[jd_doc])
 ```
 
 ---

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -210,7 +210,7 @@ Same manifest. Same execution engine. Same audit trail.
 **Features:**
 - Automatic document scanning (`.pdf`, `.docx`, `.txt`, `.md`, etc.)
 - Shared document support (e.g., a job description for all rows)
-- Integration with ExcelOrchestrator and ManifestOrchestrator via `resumes_path`/`jd_path`
+- Integration with ExcelOrchestrator and ManifestOrchestrator via `documents_path`/`shared_document_path`
 - Resume screening use case with dedicated invoke tasks
 
 **See:** [ORCHESTRATOR README.md](../ORCHESTRATOR%20README.md) for discovery usage.

--- a/docs/architecture/ORCHESTRATOR_ARCHITECTURE.md
+++ b/docs/architecture/ORCHESTRATOR_ARCHITECTURE.md
@@ -49,7 +49,7 @@ Plico provides a declarative execution engine for AI prompt workflows. Workflows
 │   │  - Load documents from 'documents' sheet or documents.yaml │
 │   │  - Initialize DocumentProcessor & DocumentRegistry       │   │
 │   │  - Validate all document paths, pre-index for RAG        │   │
-│   │  - Auto-discovery via resumes_path / jd_path             │   │
+│   │  - Auto-discovery via documents_path / shared_document_path     │   │
 │   └─────────────────────────────────────────────────────────┘   │
 │                                                                  │
 │   ┌─────────────────────────────────────────────────────────┐   │

--- a/scripts/create_screening_manifest.py
+++ b/scripts/create_screening_manifest.py
@@ -4,37 +4,50 @@
 # Contact: antquinonez@farfiner.com
 
 """
-Create a screening evaluation manifest from a folder of resumes.
+Create a screening evaluation manifest.
 
-Generates a manifest folder (YAML files) directly, without an Excel
-intermediary. Documents and batch data are injected at runtime via
-manifest_run.py --resumes-path and --jd flags.
+Generates a manifest folder (YAML files) for resume screening evaluation.
+The JD can optionally be baked into documents.yaml; resumes are always
+injected at runtime via manifest_run.py --documents-path.
 
-Supports two modes:
+Supports two scoring modes:
     - Static scoring (default): Includes scoring.yaml with predefined
       criteria. Prompts extract scores from LLM JSON responses.
     - Planning phase (--planning): Uses generator prompts to auto-derive
       scoring criteria and evaluation prompts from the JD. No scoring.yaml.
 
+Two creation modes:
+    - Template (JD baked): JD baked into documents.yaml. Resumes injected
+      at runtime via --documents-path.
+    - Template (generic): Nothing baked in. Both JD and resumes injected
+      at runtime.
+
 Usage:
-    python scripts/create_screening_manifest.py [output_dir] \
-        --resumes-path <folder> --jd <file>
+    # Template with JD baked in
+    python scripts/create_screening_manifest.py --jd <file>
+
+    # Generic template (nothing baked in)
+    python scripts/create_screening_manifest.py
+
+    # With resume count for synthesis top_n sizing
+    python scripts/create_screening_manifest.py --jd ./jd.md --resumes-path ./resumes/
 
 Examples:
-    # Static scoring mode
     python scripts/create_screening_manifest.py ./manifests/manifest_screening \
-        --resumes-path ./resumes/ --jd ./job_description.md
+        --jd ./job_description.md
 
-    # Planning phase mode (auto-derive scoring)
     python scripts/create_screening_manifest.py --planning \
-        --resumes-path ./resumes/ --jd ./jd.md
-
-    # Create only (no execution)
-    python scripts/create_screening_manifest.py --resumes-path ./resumes/ --jd ./jd.md
+        --jd ./jd.md
 
 Runtime execution:
+    # With JD baked in
     python scripts/manifest_run.py <manifest_dir> \
-        --resumes-path ./resumes/ --jd ./jd.md -c 1
+        --documents-path ./resumes/ -c 1
+
+    # With JD injected at runtime
+    python scripts/manifest_run.py <manifest_dir> \
+        --shared-document ./jd.md --shared-document-name job_description \
+        --documents-path ./resumes/ -c 1
 """
 
 from __future__ import annotations
@@ -52,6 +65,7 @@ import yaml
 from dotenv import load_dotenv
 from sample_workbooks.screening import (
     _parse_json_field,
+    create_jd_document,
     get_planning_screening_prompts,
     get_screening_scoring_criteria,
     get_screening_synthesis_prompts,
@@ -63,6 +77,8 @@ from src.config import get_config
 from src.orchestrator.discovery import discover_documents
 
 load_dotenv()
+
+DEFAULT_SYNTHESIS_TOP_N = 10
 
 
 def write_yaml(path: Path, data: dict[str, Any]) -> None:
@@ -78,13 +94,19 @@ def write_yaml(path: Path, data: dict[str, Any]) -> None:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
 
-def build_manifest_yaml(name: str, planning: bool, prompt_count: int) -> dict[str, Any]:
+def build_manifest_yaml(
+    name: str,
+    planning: bool,
+    prompt_count: int,
+    has_documents: bool = False,
+) -> dict[str, Any]:
     """Build manifest.yaml metadata.
 
     Args:
         name: Manifest name.
         planning: Whether planning phase is enabled.
         prompt_count: Number of prompts.
+        has_documents: Whether documents.yaml was written.
 
     Returns:
         Manifest metadata dict.
@@ -97,7 +119,7 @@ def build_manifest_yaml(name: str, planning: bool, prompt_count: int) -> dict[st
         "exported_at": datetime.now().isoformat(),
         "has_data": False,
         "has_clients": False,
-        "has_documents": False,
+        "has_documents": has_documents,
         "has_tools": False,
         "has_scoring": not planning,
         "has_synthesis": True,
@@ -193,9 +215,22 @@ def build_synthesis_yaml(synthesis: list[dict[str, Any]]) -> dict[str, Any]:
     return {"synthesis": parsed}
 
 
+def build_documents_yaml(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build documents.yaml data.
+
+    Args:
+        documents: List of document definition dicts.
+
+    Returns:
+        Documents dict with 'documents' key.
+
+    """
+    return {"documents": documents}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Create a screening evaluation manifest from a folder of resumes.",
+        description="Create a screening evaluation manifest.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
@@ -208,13 +243,16 @@ def main() -> int:
     )
     parser.add_argument(
         "--resumes-path",
-        required=True,
-        help="Folder path containing resume documents to validate discovery",
+        default=None,
+        help="Folder path containing resume documents. Used to count "
+        "candidates for synthesis top_n sizing. Resumes are always "
+        "injected at runtime via --documents-path on manifest_run.py.",
     )
     parser.add_argument(
         "--jd",
-        required=True,
-        help="Path to the job description file",
+        default=None,
+        help="Path to the job description file. If provided, baked into "
+        "documents.yaml with reference_name='job_description'.",
     )
     parser.add_argument(
         "--planning",
@@ -249,6 +287,10 @@ def main() -> int:
 
     args = parser.parse_args()
 
+    if not args.resumes_path and not args.jd:
+        print("Note: Neither --resumes-path nor --jd provided.")
+        print("      Creating a generic template. All data must be injected at runtime.\n")
+
     config = get_config()
     default_client = config.get_default_client_type()
     client_type = args.client or default_client
@@ -258,31 +300,41 @@ def main() -> int:
     output_dir = args.output or str(Path(config.paths.manifest_dir) / "manifest_screening")
     manifest_path = Path(output_dir)
 
-    print(f"\nCreating screening manifest: {manifest_path}")
-    print(f"  Resumes path: {args.resumes_path}")
-    print(f"  Job description: {args.jd}")
-    print(f"  Mode: {'planning' if args.planning else 'static scoring'}")
+    mode_label = "planning" if args.planning else "static scoring"
+    creation_mode = "template (JD baked)" if args.jd else "template (generic)"
 
-    if not Path(args.jd).is_file():
+    print(f"\nCreating screening manifest: {manifest_path}")
+    print(f"  Mode: {mode_label}")
+    print(f"  Creation: {creation_mode}")
+    if args.jd:
+        print(f"  Job description: {args.jd}")
+    if args.resumes_path:
+        print(f"  Resumes path: {args.resumes_path}")
+
+    if args.jd and not Path(args.jd).is_file():
         print(f"\nError: Job description file not found: {args.jd}")
         return 1
 
-    resume_docs = discover_documents(
-        args.resumes_path,
-        extensions=extensions,
-        absolute_paths=True,
-        tags=["resume"],
+    resume_count = 0
+    if args.resumes_path:
+        resume_docs = discover_documents(
+            args.resumes_path,
+            extensions=extensions,
+            absolute_paths=True,
+            tags=["resume"],
+        )
+        resume_count = len(resume_docs)
+        if resume_count > 0:
+            print(f"  Discovered {resume_count} documents")
+        else:
+            print(f"  Warning: No documents found in {args.resumes_path}")
+
+    synthesis_top_n = (
+        max(resume_count, DEFAULT_SYNTHESIS_TOP_N) if resume_count > 0 else DEFAULT_SYNTHESIS_TOP_N
     )
 
-    if not resume_docs:
-        print(f"\nError: No documents found in {args.resumes_path}")
-        print(f"  Extensions: {', '.join(sorted(extensions))}")
-        return 1
-
-    print(f"  Discovered {len(resume_docs)} documents")
-
     prompts = get_planning_screening_prompts() if args.planning else get_static_screening_prompts()
-    synthesis = get_screening_synthesis_prompts(top_n=len(resume_docs))
+    synthesis = get_screening_synthesis_prompts(top_n=synthesis_top_n)
     batch_config = config.workbook.batch
 
     manifest_name = (
@@ -291,9 +343,13 @@ def main() -> int:
         else manifest_path.name
     )
 
+    has_documents = args.jd is not None
+
     write_yaml(
         manifest_path / "manifest.yaml",
-        build_manifest_yaml(manifest_name, args.planning, len(prompts)),
+        build_manifest_yaml(
+            manifest_name, args.planning, len(prompts), has_documents=has_documents
+        ),
     )
     write_yaml(
         manifest_path / "config.yaml",
@@ -322,6 +378,13 @@ def main() -> int:
         build_synthesis_yaml(synthesis),
     )
 
+    if args.jd:
+        jd_doc = create_jd_document(args.jd)
+        write_yaml(
+            manifest_path / "documents.yaml",
+            build_documents_yaml([jd_doc]),
+        )
+
     total_prompts = len(prompts)
     if args.planning:
         planning_count = sum(1 for p in prompts if p.phase == "planning")
@@ -334,27 +397,36 @@ def main() -> int:
         prompt_summary = f"{total_prompts} evaluation prompts"
 
     print(f"\n{'=' * 60}")
-    print(f"Created screening ({'planning' if args.planning else 'static'}) manifest")
+    print(f"Created screening ({mode_label}) manifest")
     print(f"{'=' * 60}")
     print(f"Manifest path:   {manifest_path}")
-    print(f"Resumes:         {len(resume_docs)} discovered")
-    print(f"Job description: {args.jd}")
+    print(f"Creation mode:   {creation_mode}")
+    if args.jd:
+        print(f"Job description: baked in ({args.jd})")
+    else:
+        print("Job description: inject at runtime (--shared-document)")
+    if resume_count > 0:
+        print(f"Resumes:         {resume_count} discovered (injected at runtime)")
+    else:
+        print("Resumes:         inject at runtime (--documents-path)")
     print(f"Prompts:         {prompt_summary}")
     print(
         f"Scoring:         {'Auto-derived from planning phase' if args.planning else 'Static (5 criteria)'}"
     )
     print(f"Synthesis:       {len(synthesis)} prompts")
     print(f"Client:          {client_type}")
-    print("\nNote: Documents and batch data are injected at runtime, not baked in.")
-    print(
-        f"  Total batch executions: {total_prompts} prompts x {len(resume_docs)} candidates = "
-        f"{total_prompts * len(resume_docs)}"
-    )
-    print("\nRun with:")
-    print(
-        f"  python scripts/manifest_run.py {manifest_path} "
-        f"--resumes-path {args.resumes_path} --jd {args.jd} -c 1"
-    )
+
+    if args.jd:
+        print("\nRun with:")
+        print(f"  python scripts/manifest_run.py {manifest_path} --documents-path ./resumes/ -c 1")
+    else:
+        print("\nRun with:")
+        print(
+            f"  python scripts/manifest_run.py {manifest_path} "
+            f"--shared-document ./jd.md --shared-document-name job_description "
+            f"--documents-path ./resumes/ -c 1"
+        )
+
     print(f"{'=' * 60}\n")
 
     return 0

--- a/scripts/create_screening_workbook.py
+++ b/scripts/create_screening_workbook.py
@@ -4,33 +4,42 @@
 # Contact: antquinonez@farfiner.com
 
 """
-Create a screening evaluation workbook from a folder of resumes.
+Create a screening evaluation workbook.
 
-Auto-discovers documents from --resumes-path, adds a job description from
---jd, and creates a complete .xlsx workbook ready for the orchestrator.
+Creates a .xlsx workbook with prompts, scoring, and synthesis sheets for
+resume screening. Documents and batch data can be baked in or injected
+at runtime via the orchestrator.
 
-Supports two modes:
+Supports two scoring modes:
     - Static scoring (default): Includes a scoring sheet with predefined
       criteria. Prompts extract scores from LLM JSON responses.
     - Planning phase (--planning): Uses generator prompts to auto-derive
       scoring criteria and evaluation prompts from the JD. No scoring sheet.
 
+Three creation modes:
+    - Self-contained: JD and resumes baked in. Run with no flags.
+    - Template (JD baked): JD baked in, resumes injected at runtime.
+    - Template (generic): Nothing baked in. All injected at runtime.
+
 Usage:
+    # Self-contained (JD + resumes baked in)
     python scripts/create_screening_workbook.py <output_path> \
         --resumes-path <folder> --jd <file>
 
+    # Template with JD baked in
+    python scripts/create_screening_workbook.py <output_path> --jd <file>
+
+    # Generic template (nothing baked in)
+    python scripts/create_screening_workbook.py <output_path>
+
 Examples:
-    # Static scoring mode
     python scripts/create_screening_workbook.py ./screening.xlsx \
         --resumes-path ./resumes/ --jd ./job_description.md
 
-    # Planning phase mode (auto-derive scoring)
-    python scripts/create_screening_workbook.py ./screening.xlsx \
-        --resumes-path ./resumes/ --jd ./jd.md --planning
+    python scripts/create_screening_workbook.py ./template.xlsx \
+        --jd ./jd.md --planning
 
-    # With custom file extensions
-    python scripts/create_screening_workbook.py ./screening.xlsx \
-        --resumes-path ./resumes/ --jd ./jd.md --extensions .pdf .docx .txt .md
+    python scripts/create_screening_workbook.py ./template.xlsx
 """
 
 from __future__ import annotations
@@ -59,10 +68,12 @@ from src.orchestrator.discovery import (
 
 load_dotenv()
 
+DEFAULT_SYNTHESIS_TOP_N = 10
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Create a screening evaluation workbook from a folder of resumes.",
+        description="Create a screening evaluation workbook.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
@@ -72,13 +83,17 @@ def main() -> int:
     )
     parser.add_argument(
         "--resumes-path",
-        required=True,
-        help="Folder path containing resume documents to auto-discover",
+        default=None,
+        help="Folder path containing resume documents to bake in. "
+        "If omitted, resumes must be injected at runtime via "
+        "--documents-path on run_orchestrator.py.",
     )
     parser.add_argument(
         "--jd",
-        required=True,
-        help="Path to the job description file",
+        default=None,
+        help="Path to the job description file to bake in. "
+        "If omitted, a JD must be injected at runtime via "
+        "--shared-document on run_orchestrator.py.",
     )
     parser.add_argument(
         "--planning",
@@ -113,6 +128,10 @@ def main() -> int:
 
     args = parser.parse_args()
 
+    if not args.resumes_path and not args.jd:
+        print("Note: Neither --resumes-path nor --jd provided.")
+        print("      Creating a generic template. All data must be injected at runtime.\n")
+
     config = get_config()
     app_config = config
     default_client = app_config.get_default_client_type()
@@ -120,32 +139,58 @@ def main() -> int:
 
     extensions = {ext if ext.startswith(".") else f".{ext}" for ext in args.extensions}
 
+    mode_label = "planning" if args.planning else "static scoring"
+    if args.resumes_path and args.jd:
+        creation_mode = "self-contained"
+    elif args.jd:
+        creation_mode = "template (JD baked)"
+    elif args.resumes_path:
+        creation_mode = "template (resumes baked)"
+    else:
+        creation_mode = "template (generic)"
+
     print(f"\nCreating screening workbook: {args.output}")
-    print(f"  Resumes path: {args.resumes_path}")
-    print(f"  Job description: {args.jd}")
-    print(f"  Mode: {'planning' if args.planning else 'static scoring'}")
+    print(f"  Mode: {mode_label}")
+    print(f"  Creation: {creation_mode}")
+    if args.jd:
+        print(f"  Job description: {args.jd}")
+    if args.resumes_path:
+        print(f"  Resumes path: {args.resumes_path}")
 
-    jd_doc = create_jd_document(args.jd)
+    all_documents: list[dict[str, str | list[str]]] = []
+    data_rows: list[dict[str, str | int]] = []
+    resume_docs: list[dict[str, str | list[str]]] = []
 
-    resume_docs = discover_documents(
-        args.resumes_path,
-        extensions=extensions,
-        absolute_paths=True,
-        tags=["resume"],
+    if args.jd:
+        jd_doc = create_jd_document(args.jd)
+        all_documents.append(jd_doc)
+
+    if args.resumes_path:
+        resume_docs = discover_documents(
+            args.resumes_path,
+            extensions=extensions,
+            absolute_paths=True,
+            tags=["resume"],
+        )
+
+        if not resume_docs:
+            print(f"\nError: No documents found in {args.resumes_path}")
+            print(f"  Extensions: {', '.join(sorted(extensions))}")
+            return 1
+
+        print(f"  Discovered {len(resume_docs)} documents")
+        all_documents.extend(resume_docs)
+        data_rows = create_data_rows_from_documents(resume_docs)
+
+    candidate_count = len(data_rows)
+    synthesis_top_n = (
+        max(candidate_count, DEFAULT_SYNTHESIS_TOP_N)
+        if candidate_count > 0
+        else DEFAULT_SYNTHESIS_TOP_N
     )
 
-    if not resume_docs:
-        print(f"\nError: No documents found in {args.resumes_path}")
-        print(f"  Extensions: {', '.join(sorted(extensions))}")
-        return 1
-
-    print(f"  Discovered {len(resume_docs)} documents")
-
-    all_documents = [jd_doc, *resume_docs]
-    data_rows = create_data_rows_from_documents(resume_docs)
-
     prompts = get_planning_screening_prompts() if args.planning else get_static_screening_prompts()
-    synthesis = get_screening_synthesis_prompts(top_n=len(resume_docs))
+    synthesis = get_screening_synthesis_prompts(top_n=synthesis_top_n)
 
     batch_config = config.workbook.batch
 
@@ -178,8 +223,11 @@ def main() -> int:
             ),
         ],
     )
-    builder.add_documents_sheet(all_documents)
-    builder.add_data_sheet(data_rows)
+
+    if all_documents:
+        builder.add_documents_sheet(all_documents)
+    if data_rows:
+        builder.add_data_sheet(data_rows)
 
     if not args.planning:
         builder.add_scoring_sheet(get_screening_scoring_criteria())
@@ -199,23 +247,37 @@ def main() -> int:
     else:
         prompt_summary = f"{total_prompts} evaluation prompts"
 
+    summary_extra: dict[str, str] = {
+        "Creation mode": creation_mode,
+        "Prompts": prompt_summary,
+        "Scoring": "Auto-derived from planning phase" if args.planning else "Static (5 criteria)",
+        "Synthesis prompts": str(len(synthesis)),
+        "Client": client_type,
+    }
+    if args.jd:
+        summary_extra["Job description"] = jd_doc["file_path"]
+    if candidate_count > 0:
+        summary_extra["Resumes discovered"] = str(candidate_count)
+        summary_extra["Candidates (batch rows)"] = str(candidate_count)
+        summary_extra["Total batch executions"] = (
+            f"{total_prompts} prompts x {candidate_count} candidates = "
+            f"{total_prompts * candidate_count}"
+        )
+
+    run_flags: list[str] = []
+    if args.jd and not args.resumes_path:
+        run_flags.append("--documents-path ./resumes/")
+    elif not args.jd:
+        run_flags.append("--shared-document ./jd.md --shared-document-name job_description")
+        run_flags.append("--documents-path ./resumes/")
+    run_command = f"python scripts/run_orchestrator.py {args.output} -c 1"
+    if run_flags:
+        run_command += " \\\n    " + " \\\n    ".join(run_flags)
+
     builder.print_summary(
-        f"screening ({'planning' if args.planning else 'static'})",
-        {
-            "Resumes discovered": len(resume_docs),
-            "Job description": jd_doc["file_path"],
-            "Documents total": len(all_documents),
-            "Candidates (batch rows)": len(data_rows),
-            "Prompts": prompt_summary,
-            "Scoring": "Auto-derived from planning phase"
-            if args.planning
-            else "Static (5 criteria)",
-            "Synthesis prompts": len(synthesis),
-            "Client": client_type,
-            "Total batch executions": f"{total_prompts} prompts x {len(data_rows)} candidates = "
-            f"{total_prompts * len(data_rows)}",
-        },
-        run_command=f"python scripts/run_orchestrator.py {args.output} -c 1",
+        f"screening ({mode_label})",
+        summary_extra,
+        run_command=run_command,
     )
 
     return 0

--- a/scripts/manifest_run.py
+++ b/scripts/manifest_run.py
@@ -19,9 +19,9 @@ Examples:
     # Dry run to validate manifest
     python scripts/manifest_run.py ./manifests/manifest_my_prompts --dry-run
 
-    # Run with auto-discovered resumes and a job description
+    # Run with auto-discovered documents and a shared document
     python scripts/manifest_run.py ./manifests/manifest_screening \
-        --resumes-path ./resumes/ --jd ./job_description.md -c 1
+        --documents-path ./resumes/ --shared-document ./job_description.md -c 1
 
 Output:
     Results are written to a parquet file:
@@ -91,14 +91,19 @@ def main():
     )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     parser.add_argument(
-        "--resumes-path",
-        help="Folder path to auto-discover documents (e.g., resumes). "
+        "--documents-path",
+        help="Folder path to auto-discover documents. "
         "Populates documents and batch data at runtime without modifying the manifest.",
     )
     parser.add_argument(
-        "--jd",
-        help="Path to a job description file. Added as a shared document "
-        "with reference_name='job_description' available to all prompts.",
+        "--shared-document",
+        help="Path to a shared document file (e.g., job description, rubric). "
+        "Added to the documents registry under a reference name derived from the filename.",
+    )
+    parser.add_argument(
+        "--shared-document-name",
+        help="Explicit reference name for the shared document (e.g., 'job_description'). "
+        "Required when the filename doesn't match the reference name used in prompts.",
     )
 
     args = parser.parse_args()
@@ -198,18 +203,19 @@ def main():
         client=client,
         concurrency=args.concurrency,
         progress_callback=progress.update,
-        resumes_path=args.resumes_path,
-        jd_path=args.jd,
+        documents_path=args.documents_path,
+        shared_document_path=args.shared_document,
+        shared_document_name=args.shared_document_name,
     )
 
     print(f"\nStarting orchestration with concurrency={args.concurrency}")
     print(f"Client type: {client_type}")
     print(f"Total prompts: {len(prompts)}")
     print(f"Output directory: {output_dir}")
-    if args.resumes_path:
-        print(f"Resumes path: {args.resumes_path} (auto-discovered)")
-    if args.jd:
-        print(f"Job description: {args.jd}")
+    if args.documents_path:
+        print(f"Documents path: {args.documents_path} (auto-discovered)")
+    if args.shared_document:
+        print(f"Shared document: {args.shared_document}")
     print()
 
     parquet_path = orchestrator.run()

--- a/scripts/run_orchestrator.py
+++ b/scripts/run_orchestrator.py
@@ -22,9 +22,9 @@ Examples:
     # Run with logging to file only (quiet mode)
     python scripts/run_orchestrator.py my_prompts.xlsx --quiet
 
-    # Run with auto-discovered resumes and a job description
+    # Run with auto-discovered documents and a shared document
     python scripts/run_orchestrator.py screening.xlsx \
-        --resumes-path ./resumes/ --jd ./job_description.md -c 1
+        --documents-path ./resumes/ --shared-document ./job_description.md -c 1
 """
 
 import argparse
@@ -88,14 +88,19 @@ def main():
     )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     parser.add_argument(
-        "--resumes-path",
-        help="Folder path to auto-discover documents (e.g., resumes). "
+        "--documents-path",
+        help="Folder path to auto-discover documents. "
         "Populates documents and batch data at runtime without modifying the workbook.",
     )
     parser.add_argument(
-        "--jd",
-        help="Path to a job description file. Added as a shared document "
-        "with reference_name='job_description' available to all prompts.",
+        "--shared-document",
+        help="Path to a shared document file (e.g., job description, rubric). "
+        "Added to the documents registry under a reference name derived from the filename.",
+    )
+    parser.add_argument(
+        "--shared-document-name",
+        help="Explicit reference name for the shared document (e.g., 'job_description'). "
+        "Required when the filename doesn't match the reference name used in prompts.",
     )
 
     args = parser.parse_args()
@@ -171,17 +176,18 @@ def main():
         client=client,
         concurrency=args.concurrency,
         progress_callback=progress.update,
-        resumes_path=args.resumes_path,
-        jd_path=args.jd,
+        documents_path=args.documents_path,
+        shared_document_path=args.shared_document,
+        shared_document_name=args.shared_document_name,
     )
 
     print(f"\nStarting orchestration with concurrency={args.concurrency}")
     print(f"Client type: {client_type}")
     print(f"Total prompts: {len(prompts)}")
-    if args.resumes_path:
-        print(f"Resumes path: {args.resumes_path} (auto-discovered)")
-    if args.jd:
-        print(f"Job description: {args.jd}")
+    if args.documents_path:
+        print(f"Documents path: {args.documents_path} (auto-discovered)")
+    if args.shared_document:
+        print(f"Shared document: {args.shared_document}")
     log_dir = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))), app_config.logging.directory
     )

--- a/scripts/sample_workbooks/screening.py
+++ b/scripts/sample_workbooks/screening.py
@@ -312,7 +312,7 @@ def create_jd_document(jd_path: str) -> dict[str, Any]:
         "reference_name": "job_description",
         "common_name": "Job Description",
         "file_path": str(path),
-        "tags": "jd",
+        "tags": "shared",
         "chunking_strategy": "",
         "notes": f"Shared job description: {path.name}",
     }

--- a/src/orchestrator/base/orchestrator_base.py
+++ b/src/orchestrator/base/orchestrator_base.py
@@ -82,8 +82,9 @@ class OrchestratorBase(ABC):
         config_overrides: dict[str, Any] | None = None,
         concurrency: int | None = None,
         progress_callback: Callable[..., None] | None = None,
-        resumes_path: str | None = None,
-        jd_path: str | None = None,
+        documents_path: str | None = None,
+        shared_document_path: str | None = None,
+        shared_document_name: str | None = None,
     ) -> None:
         """Initialize the orchestrator base.
 
@@ -92,13 +93,23 @@ class OrchestratorBase(ABC):
             config_overrides: Optional config overrides.
             concurrency: Maximum concurrent API calls (1-max). Uses config default if None.
             progress_callback: Optional callback for progress updates.
-            resumes_path: Optional folder path to auto-discover documents (e.g., resumes).
-            jd_path: Optional path to a job description file.
+            documents_path: Optional folder path to auto-discover documents.
+                Discovered documents populate the documents registry and batch
+                data at runtime without modifying the source.
+            shared_document_path: Optional path to a shared document file (e.g.,
+                a job description, rubric, or reference document) added to the
+                documents registry.
+            shared_document_name: Optional reference name for the shared document.
+                When provided, this is used as the ``reference_name`` in the
+                documents registry (e.g., ``"job_description"``). When omitted,
+                the name is derived from the filename stem using snake_case
+                sanitization.
 
         """
         self.client = client
-        self._resumes_path = resumes_path
-        self._jd_path = jd_path
+        self._documents_path = documents_path
+        self._shared_document_path = shared_document_path
+        self._shared_document_name = shared_document_name
         self.config_overrides = config_overrides or {}
 
         config = get_config()
@@ -1501,33 +1512,43 @@ class OrchestratorBase(ABC):
                 )
 
     @staticmethod
-    def _resolve_jd_document(jd_path: str) -> dict[str, Any]:
-        """Create a document definition for a job description file.
+    def _resolve_shared_document(
+        document_path: str,
+        reference_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a document definition for a shared document file.
 
         Args:
-            jd_path: Path to the job description file.
+            document_path: Path to the shared document file.
+            reference_name: Optional reference name. If not provided, derived
+                from the filename stem using snake_case sanitization.
 
         Returns:
-            Document definition dict with reference_name="job_description".
+            Document definition dict suitable for the documents registry.
 
         """
         from pathlib import Path
 
-        path = Path(jd_path).resolve()
+        path = Path(document_path).resolve()
         if not path.is_file():
-            raise FileNotFoundError(f"Job description file not found: {jd_path}")
+            raise FileNotFoundError(f"Shared document file not found: {document_path}")
+
+        if reference_name is None:
+            import re
+
+            reference_name = re.sub(r"[^a-z0-9_]+", "_", path.stem.lower()).strip("_")
 
         return {
-            "reference_name": "job_description",
-            "common_name": "Job Description",
+            "reference_name": reference_name,
+            "common_name": path.stem,
             "file_path": str(path),
-            "tags": "jd",
+            "tags": "shared",
             "chunking_strategy": "",
-            "notes": f"Shared job description: {path.name}",
+            "notes": f"Shared document: {path.name}",
         }
 
     def _inject_discovery_overrides(self, source_dir: str) -> None:
-        """Inject documents and batch data from resumes_path and jd_path.
+        """Inject documents and batch data from documents_path and shared_document_path.
 
         Called by subclasses during _load_source() after loading their own
         documents and batch data. Discovered documents merge with any
@@ -1542,36 +1563,41 @@ class OrchestratorBase(ABC):
 
         discovered_docs: list[dict[str, Any]] = []
 
-        if self._jd_path:
-            jd_doc = self._resolve_jd_document(self._jd_path)
-            discovered_docs.append(jd_doc)
-            logger.info(f"Injected JD as shared document: {jd_doc['file_path']}")
-
-        if self._resumes_path:
-            resume_docs = discover_documents(
-                self._resumes_path,
-                absolute_paths=True,
-                tags=["resume"],
+        if self._shared_document_path:
+            shared_doc = self._resolve_shared_document(
+                self._shared_document_path,
+                reference_name=self._shared_document_name,
             )
-            if not resume_docs:
-                logger.warning(f"No documents discovered in resumes_path: {self._resumes_path}")
+            discovered_docs.append(shared_doc)
+            logger.info(
+                f"Injected shared document '{shared_doc['reference_name']}': "
+                f"{shared_doc['file_path']}"
+            )
+
+        if self._documents_path:
+            folder_docs = discover_documents(
+                self._documents_path,
+                absolute_paths=True,
+            )
+            if not folder_docs:
+                logger.warning(f"No documents discovered in documents_path: {self._documents_path}")
             else:
-                discovered_docs.extend(resume_docs)
+                discovered_docs.extend(folder_docs)
                 logger.info(
-                    f"Discovered {len(resume_docs)} documents from resumes_path: "
-                    f"{self._resumes_path}"
+                    f"Discovered {len(folder_docs)} documents from documents_path: "
+                    f"{self._documents_path}"
                 )
 
-                resume_data = create_data_rows_from_documents(resume_docs)
+                folder_data = create_data_rows_from_documents(folder_docs)
                 if self.batch_data:
-                    self.batch_data.extend(resume_data)
+                    self.batch_data.extend(folder_data)
                     logger.info(
-                        f"Appended {len(resume_data)} batch rows to existing "
-                        f"{len(self.batch_data) - len(resume_data)} source rows"
+                        f"Appended {len(folder_data)} batch rows to existing "
+                        f"{len(self.batch_data) - len(folder_data)} source rows"
                     )
                 else:
-                    self.batch_data = resume_data
-                    logger.info(f"Created {len(resume_data)} batch rows from discovered documents")
+                    self.batch_data = folder_data
+                    logger.info(f"Created {len(folder_data)} batch rows from discovered documents")
 
                 self.is_batch_mode = len(self.batch_data) > 0
 

--- a/src/orchestrator/discovery.py
+++ b/src/orchestrator/discovery.py
@@ -139,20 +139,24 @@ def discover_documents(
 def create_data_rows_from_documents(
     document_defs: list[dict[str, Any]],
     documents_column: str = "_documents",
+    name_column: str = "candidate_name",
 ) -> list[dict[str, Any]]:
     """Generate data rows for batch execution from document definitions.
 
     Each document becomes one data row with ``id``, ``batch_name``,
-    ``candidate_name``, and ``_documents`` columns.
+    ``name_column``, and ``_documents`` columns.
 
     Args:
         document_defs: List of dicts as returned by ``discover_documents()``
             or matching ``DOCUMENTS_HEADERS`` format.
         documents_column: Name of the column that binds documents to rows.
+        name_column: Name of the column holding the display name for each
+            document entry (e.g., ``"candidate_name"`` for resume screening,
+            ``"document_name"`` for generic document evaluation).
 
     Returns:
-        List of dicts with keys: ``id``, ``batch_name``, ``candidate_name``,
-        ``_documents``.
+        List of dicts with keys: ``id``, ``batch_name``, ``name_column``,
+        ``documents_column``.
 
     """
     rows: list[dict[str, Any]] = []
@@ -163,7 +167,7 @@ def create_data_rows_from_documents(
             {
                 "id": idx,
                 "batch_name": doc.get("reference_name", ""),
-                "candidate_name": common_name,
+                name_column: common_name,
                 documents_column: f'["{ref_name}"]',
             }
         )

--- a/src/orchestrator/excel_orchestrator.py
+++ b/src/orchestrator/excel_orchestrator.py
@@ -12,7 +12,7 @@ workflows defined in Excel workbooks with support for:
 - Document reference injection
 - Semantic search via RAG (semantic_query)
 - Conditional execution
-- Auto-discovery of documents from a folder (resumes_path)
+- Auto-discovery of documents from a folder (documents_path)
 """
 
 from __future__ import annotations
@@ -50,8 +50,9 @@ class ExcelOrchestrator(OrchestratorBase):
         config_overrides: dict[str, Any] | None = None,
         concurrency: int | None = None,
         progress_callback: Callable[..., None] | None = None,
-        resumes_path: str | None = None,
-        jd_path: str | None = None,
+        documents_path: str | None = None,
+        shared_document_path: str | None = None,
+        shared_document_name: str | None = None,
     ) -> None:
         """Initialize the ExcelOrchestrator.
 
@@ -61,12 +62,14 @@ class ExcelOrchestrator(OrchestratorBase):
             config_overrides: Optional config overrides from workbook.
             concurrency: Maximum concurrent API calls (1-max). Uses config default if None.
             progress_callback: Optional callback for progress updates.
-            resumes_path: Optional folder path to auto-discover documents (e.g., resumes).
-                Discovered documents populate the documents registry and batch data
-                at runtime without modifying the workbook.
-            jd_path: Optional path to a job description file. Added as a shared
-                document with ``reference_name="job_description"`` available to all
-                prompts via ``references: '["job_description"]'``.
+            documents_path: Optional folder path to auto-discover documents.
+                Discovered documents populate the documents registry and batch
+                data at runtime without modifying the workbook.
+            shared_document_path: Optional path to a shared document file (e.g.,
+                a job description, rubric, or reference document) added to the
+                documents registry.
+            shared_document_name: Optional reference name for the shared document.
+                When omitted, the name is derived from the filename stem.
 
         """
         super().__init__(
@@ -74,8 +77,9 @@ class ExcelOrchestrator(OrchestratorBase):
             config_overrides=config_overrides,
             concurrency=concurrency,
             progress_callback=progress_callback,
-            resumes_path=resumes_path,
-            jd_path=jd_path,
+            documents_path=documents_path,
+            shared_document_path=shared_document_path,
+            shared_document_name=shared_document_name,
         )
         self._workbook_path = workbook_path
         self.builder = WorkbookParser(workbook_path)

--- a/src/orchestrator/manifest.py
+++ b/src/orchestrator/manifest.py
@@ -269,8 +269,9 @@ class ManifestOrchestrator(OrchestratorBase):
         config_overrides: dict[str, Any] | None = None,
         concurrency: int | None = None,
         progress_callback: Callable[..., None] | None = None,
-        resumes_path: str | None = None,
-        jd_path: str | None = None,
+        documents_path: str | None = None,
+        shared_document_path: str | None = None,
+        shared_document_name: str | None = None,
     ) -> None:
         """Initialize the ManifestOrchestrator.
 
@@ -280,8 +281,9 @@ class ManifestOrchestrator(OrchestratorBase):
             config_overrides: Optional config overrides.
             concurrency: Maximum concurrent API calls.
             progress_callback: Optional callback for progress updates.
-            resumes_path: Optional folder path to auto-discover documents (e.g., resumes).
-            jd_path: Optional path to a job description file.
+            documents_path: Optional folder path to auto-discover documents.
+            shared_document_path: Optional path to a shared document file.
+            shared_document_name: Optional reference name for the shared document.
 
         """
         super().__init__(
@@ -289,8 +291,9 @@ class ManifestOrchestrator(OrchestratorBase):
             config_overrides=config_overrides,
             concurrency=concurrency,
             progress_callback=progress_callback,
-            resumes_path=resumes_path,
-            jd_path=jd_path,
+            documents_path=documents_path,
+            shared_document_path=shared_document_path,
+            shared_document_name=shared_document_name,
         )
         self._manifest_dir = Path(manifest_dir)
         self._manifest_meta: dict[str, Any] = {}
@@ -451,7 +454,7 @@ class ManifestOrchestrator(OrchestratorBase):
                 self.has_synthesis = True
                 logger.info(f"Synthesis enabled with {len(synthesis_data)} prompts")
 
-        # Inject runtime discovery overrides (resumes_path / jd_path)
+        # Inject runtime discovery overrides (documents_path / shared_document_path)
         source_dir = str(
             Path(self._source_workbook).parent
             if self._source_workbook

--- a/tasks.py
+++ b/tasks.py
@@ -737,11 +737,16 @@ def screening_create(
     extensions: str = "",
     client: str | None = None,
 ):
-    """Create a screening workbook from a folder of resumes.
+    """Create a screening workbook.
+
+    Creates a .xlsx workbook with prompts, scoring, and synthesis sheets.
+    If --resumes-path and --jd are provided, documents and batch data are
+    baked in (self-contained). If omitted, a reusable template is created
+    for runtime injection.
 
     Args:
-        resumes_path: Folder containing resume documents
-        jd: Path to job description file
+        resumes_path: Folder containing resume documents (optional)
+        jd: Path to job description file (optional)
         output: Output workbook path (default: ./screening.xlsx)
         planning: Use planning phase mode (auto-derive scoring from JD)
         extensions: Space-separated file extensions (default: .pdf .docx .doc .txt .md)
@@ -749,16 +754,12 @@ def screening_create(
 
     Examples:
         inv screening.create --resumes-path ./resumes/ --jd ./jd.md
-        inv screening.create -r ./resumes/ -j ./jd.md -o ./screen.xlsx --planning
-        inv screening.create -r ./resumes/ -j ./jd.md -e ".pdf .docx"
+        inv screening.create --jd ./jd.md --planning
+        inv screening.create --output ./template.xlsx
 
     """
-    if not resumes_path:
-        print("Error: --resumes-path / -r is required")
-        return
-    if not jd:
-        print("Error: --jd / -j is required")
-        return
+    if not resumes_path and not jd:
+        print("Note: Creating generic template. Inject data at runtime.")
 
     config = get_config()
     workbook_path = output or config.sample.workbooks.screening
@@ -766,11 +767,13 @@ def screening_create(
     planning_flag = " --planning" if planning else ""
     client_flag = f" --client {client}" if client else ""
     ext_flag = f" --extensions {extensions}" if extensions else ""
+    resumes_flag = f" --resumes-path {resumes_path}" if resumes_path else ""
+    jd_flag = f" --jd {jd}" if jd else ""
 
     _run_cmd(
         c,
-        f"python scripts/create_screening_workbook.py {workbook_path} "
-        f"--resumes-path {resumes_path} --jd {jd}{planning_flag}{client_flag}{ext_flag}",
+        f"python scripts/create_screening_workbook.py {workbook_path}"
+        f"{resumes_flag}{jd_flag}{planning_flag}{client_flag}{ext_flag}",
     )
 
 
@@ -785,9 +788,10 @@ def screening_run(
     client: str | None = None,
     concurrency: str = "1",
 ):
-    """Create a screening workbook from a folder of resumes and run it.
+    """Create a screening workbook and run it.
 
-    Combines screening.create and orchestrator execution in one command.
+    When --resumes-path and --jd are provided, creates a self-contained
+    workbook and runs it directly.
 
     Args:
         resumes_path: Folder containing resume documents
@@ -800,15 +804,11 @@ def screening_run(
 
     Examples:
         inv screening.run --resumes-path ./resumes/ --jd ./jd.md
-        inv screening.run -r ./resumes/ -j ./jd.md --planning
-        inv screening.run -r ./resumes/ -j ./jd.md -o ./screen.xlsx -c 2
+        inv screening.run --resumes-path ./resumes/ --jd ./jd.md --planning
 
     """
-    if not resumes_path:
-        print("Error: --resumes-path / -r is required")
-        return
-    if not jd:
-        print("Error: --jd / -j is required")
+    if not resumes_path or not jd:
+        print("Error: --resumes-path and --jd are both required for screening.run")
         return
 
     config = get_config()
@@ -846,11 +846,10 @@ def screening_manifest(
     client: str | None = None,
     concurrency: str = "1",
 ):
-    """Create a screening manifest from a folder of resumes and run it.
+    """Create a screening manifest and run it.
 
-    Creates manifest YAML files directly (no Excel intermediary), then
-    runs via manifest_run.py with --resumes-path and --jd for runtime
-    document injection.
+    Creates manifest YAML files (no Excel intermediary). The JD can be
+    baked into documents.yaml; resumes are always injected at runtime.
 
     Args:
         resumes_path: Folder containing resume documents
@@ -863,15 +862,11 @@ def screening_manifest(
 
     Examples:
         inv screening.manifest --resumes-path ./resumes/ --jd ./jd.md
-        inv screening.manifest -r ./resumes/ -j ./jd.md --planning
-        inv screening.manifest -r ./resumes/ -j ./jd.md -c 2
+        inv screening.manifest --resumes-path ./resumes/ --jd ./jd.md --planning
 
     """
-    if not resumes_path:
-        print("Error: --resumes-path / -r is required")
-        return
-    if not jd:
-        print("Error: --jd / -j is required")
+    if not resumes_path or not jd:
+        print("Error: --resumes-path and --jd are both required for screening.manifest")
         return
 
     planning_flag = " --planning" if planning else ""
@@ -879,7 +874,7 @@ def screening_manifest(
     ext_flag = f" --extensions {extensions}" if extensions else ""
     output_flag = f" {output}" if output else ""
 
-    print("Creating screening manifest from folder...")
+    print("Creating screening manifest...")
     _run_cmd(
         c,
         f"python scripts/create_screening_manifest.py{output_flag} "
@@ -891,10 +886,11 @@ def screening_manifest(
 
     print("\nRunning manifest orchestrator...")
     orchestrator_client = f" --client {client}" if client else ""
+
     _run_cmd(
         c,
         f"python scripts/manifest_run.py {manifest_path} "
-        f"--resumes-path {resumes_path} --jd {jd} -c {concurrency}{orchestrator_client}",
+        f"--documents-path {resumes_path} -c {concurrency}{orchestrator_client}",
     )
 
     print("\nScreening manifest complete!")

--- a/tests/test_discovery_injection.py
+++ b/tests/test_discovery_injection.py
@@ -51,27 +51,38 @@ class TestDiscoverDocumentsAbsolutePaths:
         assert Path(result[0]["file_path"]).is_absolute()
 
 
-class TestResolveJdDocument:
-    """Tests for OrchestratorBase._resolve_jd_document."""
+class TestResolveSharedDocument:
+    """Tests for OrchestratorBase._resolve_shared_document."""
 
-    def test_valid_jd_file(self, tmp_path):
+    def test_valid_shared_document(self, tmp_path):
         jd = tmp_path / "job_description.md"
         jd.write_text("Senior Engineer role...")
 
-        result = OrchestratorBase._resolve_jd_document(str(jd))
+        result = OrchestratorBase._resolve_shared_document(str(jd))
         assert result["reference_name"] == "job_description"
-        assert result["common_name"] == "Job Description"
-        assert result["tags"] == "jd"
+        assert result["common_name"] == "job_description"
+        assert result["tags"] == "shared"
         assert Path(result["file_path"]).is_absolute()
         assert "job_description.md" in result["file_path"]
 
-    def test_jd_file_not_found(self, tmp_path):
-        with pytest.raises(FileNotFoundError, match="Job description file not found"):
-            OrchestratorBase._resolve_jd_document(str(tmp_path / "nonexistent.md"))
+    def test_custom_reference_name(self, tmp_path):
+        doc = tmp_path / "my_rubric.pdf"
+        doc.write_text("Scoring rubric...")
+
+        result = OrchestratorBase._resolve_shared_document(
+            str(doc), reference_name="scoring_rubric"
+        )
+        assert result["reference_name"] == "scoring_rubric"
+        assert result["common_name"] == "my_rubric"
+        assert result["tags"] == "shared"
+
+    def test_document_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="Shared document file not found"):
+            OrchestratorBase._resolve_shared_document(str(tmp_path / "nonexistent.md"))
 
 
 class TestExcelOrchestratorInjection:
-    """Tests for ExcelOrchestrator with resumes_path and jd_path."""
+    """Tests for ExcelOrchestrator with documents_path and shared_document_path."""
 
     def _create_minimal_workbook(self, path: Path) -> None:
         """Create a minimal workbook with prompts sheet only."""
@@ -99,7 +110,25 @@ class TestExcelOrchestratorInjection:
 
         wb.save(str(path))
 
-    def test_inject_jd_only(self, tmp_path):
+    def test_inject_shared_document_only(self, tmp_path):
+        workbook = tmp_path / "test.xlsx"
+        self._create_minimal_workbook(workbook)
+
+        jd = tmp_path / "job_description.md"
+        jd.write_text("Senior Engineer role...")
+
+        client = MagicMock()
+        orchestrator = ExcelOrchestrator(
+            workbook_path=str(workbook),
+            client=client,
+            shared_document_path=str(jd),
+        )
+        orchestrator._load_source()
+
+        assert orchestrator.has_documents
+        assert "job_description" in orchestrator.document_registry.documents
+
+    def test_shared_document_name_overrides_filename(self, tmp_path):
         workbook = tmp_path / "test.xlsx"
         self._create_minimal_workbook(workbook)
 
@@ -110,14 +139,16 @@ class TestExcelOrchestratorInjection:
         orchestrator = ExcelOrchestrator(
             workbook_path=str(workbook),
             client=client,
-            jd_path=str(jd),
+            shared_document_path=str(jd),
+            shared_document_name="job_description",
         )
         orchestrator._load_source()
 
         assert orchestrator.has_documents
         assert "job_description" in orchestrator.document_registry.documents
+        assert "jd" not in orchestrator.document_registry.documents
 
-    def test_inject_resumes_only(self, tmp_path):
+    def test_inject_documents_only(self, tmp_path):
         workbook = tmp_path / "test.xlsx"
         self._create_minimal_workbook(workbook)
 
@@ -130,7 +161,7 @@ class TestExcelOrchestratorInjection:
         orchestrator = ExcelOrchestrator(
             workbook_path=str(workbook),
             client=client,
-            resumes_path=str(resumes),
+            documents_path=str(resumes),
         )
         orchestrator._load_source()
 
@@ -140,11 +171,11 @@ class TestExcelOrchestratorInjection:
         assert "alice" in orchestrator.document_registry.documents
         assert "bob" in orchestrator.document_registry.documents
 
-    def test_inject_both_jd_and_resumes(self, tmp_path):
+    def test_inject_both_shared_document_and_documents(self, tmp_path):
         workbook = tmp_path / "test.xlsx"
         self._create_minimal_workbook(workbook)
 
-        jd = tmp_path / "jd.md"
+        jd = tmp_path / "job_description.md"
         jd.write_text("Senior Engineer role...")
 
         resumes = tmp_path / "resumes"
@@ -156,8 +187,8 @@ class TestExcelOrchestratorInjection:
         orchestrator = ExcelOrchestrator(
             workbook_path=str(workbook),
             client=client,
-            resumes_path=str(resumes),
-            jd_path=str(jd),
+            documents_path=str(resumes),
+            shared_document_path=str(jd),
         )
         orchestrator._load_source()
 
@@ -180,7 +211,7 @@ class TestExcelOrchestratorInjection:
         orchestrator = ExcelOrchestrator(
             workbook_path=str(workbook),
             client=client,
-            resumes_path=str(resumes),
+            documents_path=str(resumes),
         )
         orchestrator._load_source()
 
@@ -250,7 +281,7 @@ class TestExcelOrchestratorInjection:
         orchestrator = ExcelOrchestrator(
             workbook_path=str(workbook),
             client=client,
-            resumes_path=str(resumes),
+            documents_path=str(resumes),
         )
         orchestrator._load_source()
 
@@ -303,7 +334,7 @@ class TestExcelOrchestratorInjection:
         orchestrator = ExcelOrchestrator(
             workbook_path=str(workbook),
             client=client,
-            resumes_path=str(resumes),
+            documents_path=str(resumes),
         )
         orchestrator._load_source()
 
@@ -311,7 +342,7 @@ class TestExcelOrchestratorInjection:
         assert orchestrator.batch_data[0]["batch_name"] == "existing_batch"
         assert orchestrator.batch_data[1]["batch_name"] == "alice"
 
-    def test_empty_resumes_path_warns(self, tmp_path):
+    def test_empty_documents_path_warns(self, tmp_path):
         workbook = tmp_path / "test.xlsx"
         self._create_minimal_workbook(workbook)
 
@@ -322,18 +353,18 @@ class TestExcelOrchestratorInjection:
         orchestrator = ExcelOrchestrator(
             workbook_path=str(workbook),
             client=client,
-            resumes_path=str(empty_folder),
+            documents_path=str(empty_folder),
         )
         orchestrator._load_source()
 
         assert not orchestrator.is_batch_mode
         assert len(orchestrator.batch_data) == 0
 
-    def test_jd_paths_are_absolute(self, tmp_path):
+    def test_shared_document_paths_are_absolute(self, tmp_path):
         workbook = tmp_path / "test.xlsx"
         self._create_minimal_workbook(workbook)
 
-        jd = tmp_path / "jd.md"
+        jd = tmp_path / "job_description.md"
         jd.write_text("Senior Engineer role...")
 
         resumes = tmp_path / "resumes"
@@ -344,8 +375,8 @@ class TestExcelOrchestratorInjection:
         orchestrator = ExcelOrchestrator(
             workbook_path=str(workbook),
             client=client,
-            resumes_path=str(resumes),
-            jd_path=str(jd),
+            documents_path=str(resumes),
+            shared_document_path=str(jd),
         )
         orchestrator._load_source()
 
@@ -354,7 +385,7 @@ class TestExcelOrchestratorInjection:
 
 
 class TestManifestOrchestratorInjection:
-    """Tests for ManifestOrchestrator with resumes_path and jd_path."""
+    """Tests for ManifestOrchestrator with documents_path and shared_document_path."""
 
     def _create_minimal_manifest(self, manifest_dir: Path) -> None:
         """Create a minimal manifest folder with required YAML files."""
@@ -393,7 +424,25 @@ class TestManifestOrchestratorInjection:
         with open(manifest_dir / "prompts.yaml", "w") as f:
             yaml.dump(prompts_yaml, f)
 
-    def test_inject_jd_only(self, tmp_path):
+    def test_inject_shared_document_only(self, tmp_path):
+        manifest_dir = tmp_path / "manifest"
+        self._create_minimal_manifest(manifest_dir)
+
+        jd = tmp_path / "job_description.md"
+        jd.write_text("Senior Engineer role...")
+
+        client = MagicMock()
+        orchestrator = ManifestOrchestrator(
+            manifest_dir=str(manifest_dir),
+            client=client,
+            shared_document_path=str(jd),
+        )
+        orchestrator._load_source()
+
+        assert orchestrator.has_documents
+        assert "job_description" in orchestrator.document_registry.documents
+
+    def test_shared_document_name_overrides_filename(self, tmp_path):
         manifest_dir = tmp_path / "manifest"
         self._create_minimal_manifest(manifest_dir)
 
@@ -404,14 +453,16 @@ class TestManifestOrchestratorInjection:
         orchestrator = ManifestOrchestrator(
             manifest_dir=str(manifest_dir),
             client=client,
-            jd_path=str(jd),
+            shared_document_path=str(jd),
+            shared_document_name="job_description",
         )
         orchestrator._load_source()
 
         assert orchestrator.has_documents
         assert "job_description" in orchestrator.document_registry.documents
+        assert "jd" not in orchestrator.document_registry.documents
 
-    def test_inject_resumes_only(self, tmp_path):
+    def test_inject_documents_only(self, tmp_path):
         manifest_dir = tmp_path / "manifest"
         self._create_minimal_manifest(manifest_dir)
 
@@ -424,7 +475,7 @@ class TestManifestOrchestratorInjection:
         orchestrator = ManifestOrchestrator(
             manifest_dir=str(manifest_dir),
             client=client,
-            resumes_path=str(resumes),
+            documents_path=str(resumes),
         )
         orchestrator._load_source()
 
@@ -434,11 +485,11 @@ class TestManifestOrchestratorInjection:
         assert "alice" in orchestrator.document_registry.documents
         assert "bob" in orchestrator.document_registry.documents
 
-    def test_inject_both_jd_and_resumes(self, tmp_path):
+    def test_inject_both_shared_document_and_documents(self, tmp_path):
         manifest_dir = tmp_path / "manifest"
         self._create_minimal_manifest(manifest_dir)
 
-        jd = tmp_path / "jd.md"
+        jd = tmp_path / "job_description.md"
         jd.write_text("Senior Engineer role...")
 
         resumes = tmp_path / "resumes"
@@ -450,8 +501,8 @@ class TestManifestOrchestratorInjection:
         orchestrator = ManifestOrchestrator(
             manifest_dir=str(manifest_dir),
             client=client,
-            resumes_path=str(resumes),
-            jd_path=str(jd),
+            documents_path=str(resumes),
+            shared_document_path=str(jd),
         )
         orchestrator._load_source()
 
@@ -474,7 +525,7 @@ class TestManifestOrchestratorInjection:
         orchestrator = ManifestOrchestrator(
             manifest_dir=str(manifest_dir),
             client=client,
-            resumes_path=str(resumes),
+            documents_path=str(resumes),
         )
         orchestrator._load_source()
 
@@ -558,7 +609,7 @@ class TestManifestOrchestratorInjection:
         orchestrator = ManifestOrchestrator(
             manifest_dir=str(manifest_dir),
             client=client,
-            resumes_path=str(resumes),
+            documents_path=str(resumes),
         )
         orchestrator._load_source()
 
@@ -624,7 +675,7 @@ class TestManifestOrchestratorInjection:
         orchestrator = ManifestOrchestrator(
             manifest_dir=str(manifest_dir),
             client=client,
-            resumes_path=str(resumes),
+            documents_path=str(resumes),
         )
         orchestrator._load_source()
 


### PR DESCRIPTION
## Summary

- Renames orchestrator parameters from domain-specific `resumes_path`/`jd_path` to domain-agnostic `documents_path`/`shared_document_path`/`shared_document_name`
- Updates all scripts (`run_orchestrator.py`, `manifest_run.py`, `create_screening_workbook.py`, `create_screening_manifest.py`), invoke tasks, tests, and documentation to reflect the new naming
- Harmonizes `tags` field in `create_jd_document()` to use `"shared"` (matching `_resolve_shared_document()`) for consistency between baked-in and runtime-injected shared documents
- Creation scripts retain domain-specific CLI flags (`--resumes-path`, `--jd`) while orchestrator runtime uses generalized `--documents-path`/`--shared-document`