### PR TITLE
feat: per-criteria ranking in scores_pivot and planning template refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ outputs/*
 .opencode/plans/*
 working_docs/*
 .coverage
+.opencode/package-lock.json

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -77,6 +77,17 @@ workbook:
         semantic_filter: 50
         query_expansion: 18
         rerank: 12
+      scoring:
+        batch_name: 18
+        criteria_name: 22
+        normalized_score: 16
+        weight: 10
+        weighted_score: 15
+        rank: 8
+        percentile: 12
+        scale_min: 10
+        scale_max: 10
+        description: 50
     word_wrap:
       enabled: true
       columns:

--- a/config/prompts/screening_skills_planning.yaml
+++ b/config/prompts/screening_skills_planning.yaml
@@ -24,7 +24,6 @@ prompts:
 
       EXTRACT EVERY DISCRETE REQUIREMENT including:
       - Hard skills and technologies (e.g., Python, SQL, Tableau, Excel, AWS)
-      - Soft skills (e.g., communication, leadership, collaboration, problem-solving)
       - Domain expertise (e.g., healthcare, finance, e-commerce)
       - Certifications and education requirements (e.g., CPA, MBA, AWS certification)
       - Experience requirements (e.g., "5+ years managing teams", "B2B sales experience")
@@ -70,14 +69,12 @@ prompts:
           {
             "prompt_name": "evaluate_python",
             "prompt": "Evaluate {{candidate_name}}'s Python proficiency. Consider years of experience, use of async/await, type hints, testing, and packaging. Look for evidence of complex production systems built in Python.\n\nYou MUST respond with ONLY this JSON format:\n{\"python\": <integer 1-10>, \"reasoning\": \"<brief explanation>\"}\n\nThe key MUST be \"python\" (exactly this string). Do NOT use any other key name.",
-            "references": ["job_description"],
-            "history": ["extract_profile"]
+            "references": ["job_description"]
           },
           {
             "prompt_name": "evaluate_docker",
             "prompt": "Evaluate {{candidate_name}}'s Docker expertise. Consider containerization experience, image optimization, multi-stage builds, and production deployment workflows.\n\nYou MUST respond with ONLY this JSON format:\n{\"docker\": <integer 1-10>, \"reasoning\": \"<brief explanation>\"}\n\nThe key MUST be \"docker\" (exactly this string). Do NOT use any other key name.",
-            "references": ["job_description"],
-            "history": ["extract_profile"]
+            "references": ["job_description"]
           }
         ]
       }
@@ -159,7 +156,6 @@ prompts:
       employment history (company, title, dates, responsibilities), and
       a comprehensive skills list organized by category (technical, soft skills,
       domain knowledge, certifications, methodologies).
-    references: '["job_description"]'
     notes: "Static prompt: extracts structured profile for downstream per-skill evaluation"
 
   - sequence: 200

--- a/src/Clients/FFGemini.py
+++ b/src/Clients/FFGemini.py
@@ -17,7 +17,7 @@ from openai import AsyncOpenAI
 from ..core.client_base import FFAIClientBase
 from ..retry_utils import (
     create_rate_limit_error,
-    get_retry_decorator,
+    get_configured_retry_decorator,
     should_retry_exception,
 )
 
@@ -325,28 +325,6 @@ class FFGemini(FFAIClientBase):
             logger.error(f"Error generating response: {error_str}")
             raise
 
-    @staticmethod
-    def _get_retry_decorator():
-        """Get retry decorator configured from global config."""
-        from ..config import get_config
-
-        try:
-            app_config = get_config()
-            retry_settings = getattr(app_config, "retry", None)
-
-            if retry_settings:
-                return get_retry_decorator(
-                    max_attempts=getattr(retry_settings, "max_attempts", 3),
-                    min_wait=getattr(retry_settings, "min_wait_seconds", 1),
-                    max_wait=getattr(retry_settings, "max_wait_seconds", 60),
-                    exponential_base=getattr(retry_settings, "exponential_base", 2),
-                    jitter=getattr(retry_settings, "exponential_jitter", True),
-                )
-        except Exception as e:
-            logger.debug(f"Could not load retry config: {e}")
-
-        return get_retry_decorator()
-
     async def generate_response(
         self,
         prompt: str,
@@ -380,7 +358,7 @@ class FFGemini(FFAIClientBase):
             **kwargs,
         )
 
-    @_get_retry_decorator()
+    @get_configured_retry_decorator()
     async def _generate_response_with_retry(
         self,
         prompt: str,

--- a/src/Clients/FFMistralSmall.py
+++ b/src/Clients/FFMistralSmall.py
@@ -15,7 +15,7 @@ from mistralai import Mistral
 from ..core.client_base import FFAIClientBase
 from ..retry_utils import (
     create_rate_limit_error,
-    get_retry_decorator,
+    get_configured_retry_decorator,
     should_retry_exception,
 )
 
@@ -130,29 +130,7 @@ class FFMistralSmall(FFAIClientBase):
 
         return messages
 
-    @staticmethod
-    def _get_retry_decorator():
-        """Get retry decorator configured from global config."""
-        from ..config import get_config
-
-        try:
-            app_config = get_config()
-            retry_settings = getattr(app_config, "retry", None)
-
-            if retry_settings:
-                return get_retry_decorator(
-                    max_attempts=getattr(retry_settings, "max_attempts", 3),
-                    min_wait=getattr(retry_settings, "min_wait_seconds", 1),
-                    max_wait=getattr(retry_settings, "max_wait_seconds", 60),
-                    exponential_base=getattr(retry_settings, "exponential_base", 2),
-                    jitter=getattr(retry_settings, "exponential_jitter", True),
-                )
-        except Exception as e:
-            logger.debug(f"Could not load retry config: {e}")
-
-        return get_retry_decorator()
-
-    @_get_retry_decorator()
+    @get_configured_retry_decorator()
     def generate_response(
         self,
         prompt: str,

--- a/src/orchestrator/workbook_parser.py
+++ b/src/orchestrator/workbook_parser.py
@@ -1086,10 +1086,85 @@ class WorkbookParser:
         "normalized_score",
         "weight",
         "weighted_score",
+        "rank",
+        "percentile",
         "scale_min",
         "scale_max",
         "description",
     ]
+
+    @staticmethod
+    def _compute_per_criteria_ranks(
+        rows: list[dict[str, Any]],
+    ) -> dict[tuple[str, str], tuple[int, int]]:
+        """Compute per-criteria dense rank and percentile for each row.
+
+        Rows are grouped by criteria_name. Within each group, candidates are
+        ranked by normalized_score. The key is (batch_name, criteria_name)
+        and the value is (rank, percentile).
+
+        Rows with non-numeric normalized_score are excluded from ranking.
+
+        Args:
+            rows: List of row dicts with batch_name, criteria_name, normalized_score.
+
+        Returns:
+            Mapping of (batch_name, criteria_name) to (rank, percentile).
+
+        """
+        groups: dict[str, list[tuple[str, float]]] = {}
+        for row in rows:
+            score = row.get("normalized_score")
+            if not isinstance(score, int | float):
+                continue
+            cname = row["criteria_name"]
+            groups.setdefault(cname, []).append((row["batch_name"], score))
+
+        result: dict[tuple[str, str], tuple[int, int]] = {}
+        for cname, entries in groups.items():
+            total = len(entries)
+            if total == 0:
+                continue
+            sorted_scores = sorted({s for _, s in entries}, reverse=True)
+            score_to_rank = {s: i + 1 for i, s in enumerate(sorted_scores)}
+            for batch_name, score in entries:
+                rank = score_to_rank[score]
+                percentile = 100 if total == 1 else round((total - rank) / (total - 1) * 100)
+                result[(batch_name, cname)] = (rank, percentile)
+
+        return result
+
+    @staticmethod
+    def _compute_composite_ranks(
+        composites: dict[str, float | None],
+    ) -> dict[str, tuple[int, int]]:
+        """Compute dense rank and percentile from composite scores.
+
+        Args:
+            composites: Mapping of batch_name to composite_score (may be None).
+
+        Returns:
+            Mapping of batch_name to (rank, percentile).
+
+        """
+        scored = {
+            name: score for name, score in composites.items() if isinstance(score, int | float)
+        }
+        total = len(scored)
+
+        if total == 0:
+            return {}
+
+        sorted_scores = sorted(set(scored.values()), reverse=True)
+        score_to_rank = {score: i + 1 for i, score in enumerate(sorted_scores)}
+
+        result: dict[str, tuple[int, int]] = {}
+        for name, score in scored.items():
+            rank = score_to_rank[score]
+            percentile = 100 if total == 1 else round((total - rank) / (total - 1) * 100)
+            result[name] = (rank, percentile)
+
+        return result
 
     def write_scores_pivot(
         self,
@@ -1158,7 +1233,17 @@ class WorkbookParser:
         if not rows:
             return None
 
+        criteria_ranks = self._compute_per_criteria_ranks(rows)
+        composite_ranks = self._compute_composite_ranks(composites)
+
+        for row in rows:
+            key = (row["batch_name"], row["criteria_name"])
+            rank, percentile = criteria_ranks.get(key, (0, 0))
+            row["rank"] = rank
+            row["percentile"] = percentile
+
         for batch_name, composite in composites.items():
+            rank, percentile = composite_ranks.get(batch_name, (0, 0))
             rows.append(
                 {
                     "batch_name": batch_name,
@@ -1166,6 +1251,8 @@ class WorkbookParser:
                     "normalized_score": "",
                     "weight": "",
                     "weighted_score": composite if isinstance(composite, int | float) else "",
+                    "rank": rank,
+                    "percentile": percentile,
                     "scale_min": "",
                     "scale_max": "",
                     "description": "Weighted composite score (sum of weighted scores / sum of weights)",

--- a/src/retry_utils.py
+++ b/src/retry_utils.py
@@ -85,6 +85,36 @@ def get_retry_decorator(
     )
 
 
+def get_configured_retry_decorator():
+    """Get retry decorator configured from global config, with fallback to defaults.
+
+    Reads retry settings from the application config (``config/main.yaml``).
+    Falls back to ``get_retry_decorator()`` defaults when config is unavailable.
+
+    Returns:
+        Configured retry decorator
+
+    """
+    from .config import get_config
+
+    try:
+        app_config = get_config()
+        retry_settings = getattr(app_config, "retry", None)
+
+        if retry_settings:
+            return get_retry_decorator(
+                max_attempts=getattr(retry_settings, "max_attempts", 3),
+                min_wait=getattr(retry_settings, "min_wait_seconds", 1),
+                max_wait=getattr(retry_settings, "max_wait_seconds", 60),
+                exponential_base=getattr(retry_settings, "exponential_base", 2),
+                jitter=getattr(retry_settings, "exponential_jitter", True),
+            )
+    except Exception as e:
+        logger.debug(f"Could not load retry config: {e}")
+
+    return get_retry_decorator()
+
+
 def should_retry_exception(exception: Exception) -> bool:
     """Determine if an exception should trigger a retry.
 

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -377,7 +377,7 @@ class TestScreeningSkillsPlanningTemplate:
         result = load_prompt_template("screening_skills_planning")
         profile = next(p for p in result if p.name == "extract_profile")
         assert profile.phase is None or profile.phase != "planning"
-        assert profile.references == '["job_description"]'
+        assert profile.references is None
 
     def test_skills_planning_overall_assessment_references_profile(self):
         from src.prompt_templates import load_prompt_template

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -10,6 +10,7 @@ from src.retry_utils import (
     ServiceUnavailableError,
     create_rate_limit_error,
     extract_retry_after,
+    get_configured_retry_decorator,
     get_retry_decorator,
     retry_with_backoff,
     should_retry_exception,
@@ -246,3 +247,78 @@ class TestRetryableExceptions:
 
     def test_is_tuple(self):
         assert isinstance(RETRYABLE_EXCEPTIONS, tuple)
+
+
+class TestGetConfiguredRetryDecorator:
+    def test_returns_callable(self):
+        decorator = get_configured_retry_decorator()
+        assert callable(decorator)
+
+    def test_falls_back_to_defaults_without_config(self):
+        call_count = 0
+
+        @get_configured_retry_decorator()
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RateLimitError("try again")
+            return "success"
+
+        result = flaky()
+        assert result == "success"
+        assert call_count == 3
+
+    def test_uses_config_values(self):
+        from unittest.mock import MagicMock, patch
+
+        mock_retry = MagicMock()
+        mock_retry.max_attempts = 2
+        mock_retry.min_wait_seconds = 0.01
+        mock_retry.max_wait_seconds = 0.01
+        mock_retry.exponential_base = 2
+        mock_retry.exponential_jitter = True
+
+        mock_config = MagicMock()
+        mock_config.retry = mock_retry
+
+        with patch("src.config.get_config", return_value=mock_config):
+            call_count = 0
+
+            @get_configured_retry_decorator()
+            def flaky():
+                nonlocal call_count
+                call_count += 1
+                if call_count < 2:
+                    raise RateLimitError("try again")
+                return "success"
+
+            result = flaky()
+            assert result == "success"
+            assert call_count == 2
+
+    def test_reraises_non_retryable(self):
+        @get_configured_retry_decorator()
+        def fail():
+            raise ValueError("not retryable")
+
+        with pytest.raises(ValueError, match="not retryable"):
+            fail()
+
+    def test_handles_config_import_error(self):
+        from unittest.mock import patch
+
+        with patch("src.config.get_config", side_effect=Exception("no config")):
+            call_count = 0
+
+            @get_configured_retry_decorator()
+            def flaky():
+                nonlocal call_count
+                call_count += 1
+                if call_count < 2:
+                    raise RateLimitError("try again")
+                return "ok"
+
+            result = flaky()
+            assert result == "ok"
+            assert call_count == 2

--- a/tests/test_workbook_parser.py
+++ b/tests/test_workbook_parser.py
@@ -1203,6 +1203,8 @@ class TestWorkbookParserWriteScoresPivot:
             "normalized_score",
             "weight",
             "weighted_score",
+            "rank",
+            "percentile",
             "scale_min",
             "scale_max",
             "description",
@@ -1219,6 +1221,8 @@ class TestWorkbookParserWriteScoresPivot:
                     "normalized_score": ws.cell(row=row, column=3).value,
                     "weight": ws.cell(row=row, column=4).value,
                     "weighted_score": ws.cell(row=row, column=5).value,
+                    "rank": ws.cell(row=row, column=6).value,
+                    "percentile": ws.cell(row=row, column=7).value,
                 }
             )
 
@@ -1227,24 +1231,36 @@ class TestWorkbookParserWriteScoresPivot:
         assert rows_data[0]["normalized_score"] == 8.0
         assert rows_data[0]["weight"] == 1.0
         assert rows_data[0]["weighted_score"] == 8.0
+        assert rows_data[0]["rank"] == 1
+        assert rows_data[0]["percentile"] == 100
         assert rows_data[1]["batch_name"] == "alice_chen"
         assert rows_data[1]["criteria_name"] == "education"
         assert rows_data[1]["normalized_score"] == 7.0
         assert rows_data[1]["weight"] == 0.8
         assert rows_data[1]["weighted_score"] == pytest.approx(5.6)
+        assert rows_data[1]["rank"] == 1
+        assert rows_data[1]["percentile"] == 100
         assert rows_data[2]["batch_name"] == "bob_martinez"
         assert rows_data[2]["criteria_name"] == "skills_match"
         assert rows_data[2]["normalized_score"] == 5.0
         assert rows_data[2]["weight"] == 1.0
         assert rows_data[2]["weighted_score"] == 5.0
+        assert rows_data[2]["rank"] == 2
+        assert rows_data[2]["percentile"] == 0
         assert rows_data[3]["batch_name"] == "bob_martinez"
         assert rows_data[3]["criteria_name"] == "education"
+        assert rows_data[3]["rank"] == 2
+        assert rows_data[3]["percentile"] == 0
         assert rows_data[4]["batch_name"] == "alice_chen"
         assert rows_data[4]["criteria_name"] == "_composite"
         assert rows_data[4]["weighted_score"] == 7.5
+        assert rows_data[4]["rank"] == 1
+        assert rows_data[4]["percentile"] == 100
         assert rows_data[5]["batch_name"] == "bob_martinez"
         assert rows_data[5]["criteria_name"] == "_composite"
         assert rows_data[5]["weighted_score"] == 5.5
+        assert rows_data[5]["rank"] == 2
+        assert rows_data[5]["percentile"] == 0
 
     def test_pivot_returns_none_when_no_normalized_criteria(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
@@ -1341,8 +1357,96 @@ class TestWorkbookParserWriteScoresPivot:
         ws = wb[sheet_name]
         assert ws.max_row == 3
         assert ws.cell(row=2, column=2).value == "skills_match"
+        assert ws.cell(row=2, column=6).value == 1
+        assert ws.cell(row=2, column=7).value == 100
         assert ws.cell(row=3, column=2).value == "_composite"
         assert ws.cell(row=3, column=5).value == 8.0
+        assert ws.cell(row=3, column=6).value == 1
+        assert ws.cell(row=3, column=7).value == 100
+
+    def test_pivot_per_criteria_ranking(self, temp_workbook_with_data):
+        from src.orchestrator.workbook_parser import WorkbookParser
+
+        builder = WorkbookParser(temp_workbook_with_data)
+
+        results = [
+            {
+                "batch_id": 1,
+                "batch_name": "alice",
+                "scores": {"python": 9.0, "docker": 5.0},
+                "composite_score": 7.0,
+            },
+            {
+                "batch_id": 2,
+                "batch_name": "bob",
+                "scores": {"python": 6.0, "docker": 8.0},
+                "composite_score": 7.0,
+            },
+            {
+                "batch_id": 3,
+                "batch_name": "carol",
+                "scores": {"python": 6.0, "docker": 5.0},
+                "composite_score": 5.5,
+            },
+        ]
+
+        scoring_criteria = [
+            {
+                "criteria_name": "python",
+                "description": "Python",
+                "scale_min": 1,
+                "scale_max": 10,
+                "weight": 1.0,
+                "source_prompt": "eval",
+                "score_type": "normalized_score",
+            },
+            {
+                "criteria_name": "docker",
+                "description": "Docker",
+                "scale_min": 1,
+                "scale_max": 10,
+                "weight": 1.0,
+                "source_prompt": "eval",
+                "score_type": "normalized_score",
+            },
+        ]
+
+        sheet_name = builder.write_scores_pivot(results, scoring_criteria)
+        assert sheet_name is not None
+
+        wb = load_workbook(temp_workbook_with_data)
+        ws = wb[sheet_name]
+
+        rows_by_key = {}
+        for row in range(2, ws.max_row + 1):
+            bn = ws.cell(row=row, column=1).value
+            cn = ws.cell(row=row, column=2).value
+            rows_by_key[(bn, cn)] = {
+                "normalized_score": ws.cell(row=row, column=3).value,
+                "rank": ws.cell(row=row, column=6).value,
+                "percentile": ws.cell(row=row, column=7).value,
+            }
+
+        assert rows_by_key[("alice", "python")]["rank"] == 1
+        assert rows_by_key[("alice", "python")]["percentile"] == 100
+        assert rows_by_key[("bob", "python")]["rank"] == 2
+        assert rows_by_key[("bob", "python")]["percentile"] == 50
+        assert rows_by_key[("carol", "python")]["rank"] == 2
+        assert rows_by_key[("carol", "python")]["percentile"] == 50
+
+        assert rows_by_key[("bob", "docker")]["rank"] == 1
+        assert rows_by_key[("bob", "docker")]["percentile"] == 100
+        assert rows_by_key[("alice", "docker")]["rank"] == 2
+        assert rows_by_key[("alice", "docker")]["percentile"] == 50
+        assert rows_by_key[("carol", "docker")]["rank"] == 2
+        assert rows_by_key[("carol", "docker")]["percentile"] == 50
+
+        assert rows_by_key[("alice", "_composite")]["rank"] == 1
+        assert rows_by_key[("alice", "_composite")]["percentile"] == 100
+        assert rows_by_key[("bob", "_composite")]["rank"] == 1
+        assert rows_by_key[("bob", "_composite")]["percentile"] == 100
+        assert rows_by_key[("carol", "_composite")]["rank"] == 2
+        assert rows_by_key[("carol", "_composite")]["percentile"] == 50
 
     def test_pivot_deduplicates_per_batch(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
@@ -1381,4 +1485,8 @@ class TestWorkbookParserWriteScoresPivot:
         ws = wb[sheet_name]
         assert ws.max_row == 3
         assert ws.cell(row=2, column=2).value == "skills_match"
+        assert ws.cell(row=2, column=6).value == 1
+        assert ws.cell(row=2, column=7).value == 100
         assert ws.cell(row=3, column=2).value == "_composite"
+        assert ws.cell(row=3, column=6).value == 1
+        assert ws.cell(row=3, column=7).value == 100


### PR DESCRIPTION
## Summary

- Add **rank** and **percentile** columns to the `scores_pivot` sheet, computed per-criteria (each candidate ranked against peers on the same skill) with separate composite ranking for `_composite` rows. Dense ranking with ties receiving the same rank.
- Refine `screening_skills_planning` prompt template: remove `extract_profile` from history/references in generated prompt examples to eliminate redundant context injection, and remove soft skills from the JD decomposition list.
- Extract shared `get_configured_retry_decorator` utility to eliminate retry decorator duplication across clients.

## Changes

| File | Change |
|------|--------|
| `src/orchestrator/workbook_parser.py` | Add `_compute_per_criteria_ranks`, `_compute_composite_ranks`, rank/percentile columns |
| `config/main.yaml` | Add scoring column widths for new pivot columns |
| `config/prompts/screening_skills_planning.yaml` | Remove extract_profile from history, remove soft skills from decomposition |
| `src/retry_utils.py` | Extract shared retry decorator |
| `src/Clients/FFGemini.py`, `FFMistralSmall.py` | Use shared retry decorator |
| Tests | New `test_pivot_per_criteria_ranking` test, updated existing pivot and template tests |