### PR TITLE
refactor: extract ResultsFrame, fix synthesis deserialization, normalize invoke tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,10 @@ dependencies = [
     "azure-ai-inference>=1.0.0b9,<2.0.0",
     "azure-core>=1.38.0,<2.0.0",
     "google-auth>=2.48.0,<3.0.0",
-    "duckdb>=1.4.0,<2.0.0",
     "requests>=2.32.0,<3.0.0",
-    "pandas>=3.0.0,<4.0.0",
     "polars[rtcompat]>=1.38.0,<2.0.0",
     "python-dotenv>=1.2.0,<2.0.0",
     "nest_asyncio>=1.6.0,<2.0.0",
-    "matplotlib>=3.10.0,<4.0.0",
     "openpyxl>=3.1.0,<4.0.0",
     "pyarrow>=23.0.0,<25.0.0",
     "litellm>=1.81.0,<2.0.0",
@@ -49,6 +46,11 @@ otel = [
     "opentelemetry-api>=1.40.0",
     "opentelemetry-sdk>=1.40.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.40.0",
+]
+
+scripts = [
+    "pandas>=3.0.0,<4.0.0",
+    "matplotlib>=3.10.0,<4.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/manifest_inspect.py
+++ b/scripts/manifest_inspect.py
@@ -45,6 +45,8 @@ import polars as pl
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from src.orchestrator.results import ResultsFrame
+
 
 def inspect_parquet(
     parquet_path: str,
@@ -112,11 +114,13 @@ def inspect_parquet(
     print("\nSTATISTICS:")
     print("-" * 70)
 
-    status_counts = df.group_by("status").len()
-    for row in status_counts.iter_rows(named=True):
-        status = row["status"]
-        count = row["len"]
-        pct = (count / len(df) * 100) if len(df) > 0 else 0
+    frame = ResultsFrame.from_parquet(parquet_path)
+    summary = frame.summary(is_batch_mode=True)
+
+    for status in ("success", "failed", "skipped"):
+        count = summary.get(status, 0)
+        total = summary.get("total_prompts", len(df))
+        pct = (count / total * 100) if total > 0 else 0
         print(f"  {status}: {count} ({pct:.1f}%)")
 
     attempts_stats = df.select(
@@ -131,8 +135,7 @@ def inspect_parquet(
     )
 
     if "batch_id" in df.columns and df["batch_id"].null_count() < len(df):
-        batch_ids = df.filter(pl.col("batch_id").is_not_null()).select("batch_id").n_unique()
-        print(f"  Batches: {batch_ids}")
+        print(f"  Batches: {summary.get('total_batches', 'n/a')}")
 
     if "client" in df.columns and df["client"].null_count() < len(df):
         clients = df.filter(pl.col("client").is_not_null()).select("client").unique()
@@ -165,40 +168,60 @@ def inspect_parquet(
         ]
 
     def format_table(dataframe, cols, is_full=False, is_extended=False):
-        pd_df = dataframe.select(cols).to_pandas()
+        result = dataframe.select(cols)
         for col in cols:
-            if col not in pd_df.columns:
+            if col not in result.columns:
                 continue
             if col == "batch_name":
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:12]
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 12)
+                )
             elif col == "prompt_name":
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:22]
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 22)
+                )
             elif col == "prompt":
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:40]
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 40)
+                )
             elif col == "response":
                 max_len = 80 if is_extended else 50
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:max_len]
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, max_len)
+                )
             elif col == "history":
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:30]
-            elif col == "condition" or col == "references":
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:25]
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 30)
+                )
+            elif col in ("condition", "references"):
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 25)
+                )
             elif col == "error":
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:30]
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 30)
+                )
             elif col == "client":
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:10]
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 10)
+                )
             elif col in ("batch_id", "sequence", "attempts"):
-                pd_df[col] = pd_df[col].fillna("-").astype(str)
+                result = result.with_columns(pl.col(col).fill_null("-").cast(pl.Utf8))
             elif col == "condition_result":
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:8]
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 8)
+                )
             else:
-                pd_df[col] = pd_df[col].fillna("-").astype(str).str[:15]
-        return pd_df
+                result = result.with_columns(
+                    pl.col(col).fill_null("-").cast(pl.Utf8).str.slice(0, 15)
+                )
+        return result
 
     if show_all:
         print("\nDATA (ALL ROWS):")
         print("-" * 120)
         formatted = format_table(df, available_cols, is_full=full, is_extended=extended)
-        print(formatted.to_string(index=False))
+        print(formatted)
         print(f"\nTotal rows: {len(df)}")
     else:
         view_name = "FULL" if full else "EXTENDED" if extended else ""
@@ -206,14 +229,14 @@ def inspect_parquet(
         print("-" * 120)
         first_10 = df.head(10)
         formatted = format_table(first_10, available_cols, is_full=full, is_extended=extended)
-        print(formatted.to_string(index=False))
+        print(formatted)
 
         if len(df) > 20:
             print(f"\nDATA PREVIEW {view_name}(LAST 10 ROWS):".strip())
             print("-" * 120)
             last_10 = df.tail(10)
             formatted = format_table(last_10, available_cols, is_full=full, is_extended=extended)
-            print(formatted.to_string(index=False))
+            print(formatted)
         elif len(df) > 10:
             remaining = len(df) - 10
             print(f"\n... and {remaining} more rows")

--- a/scripts/parquet_to_excel.py
+++ b/scripts/parquet_to_excel.py
@@ -29,10 +29,8 @@ Examples:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import polars as pl
@@ -41,6 +39,8 @@ from openpyxl.styles import Alignment, Font, PatternFill
 from openpyxl.utils import get_column_letter
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.orchestrator.results.frame import _serialize_for_excel
 
 COLUMN_WIDTHS = {
     "batch_id": 10,
@@ -123,16 +123,7 @@ def export_to_excel(
     for row_idx, row in enumerate(df.iter_rows(named=True), start=2):
         for col_idx, col_name in enumerate(headers, start=1):
             value = row.get(col_name)
-
-            if value is None:
-                cell_value = ""
-            elif isinstance(value, list):
-                cell_value = json.dumps(value)
-            elif isinstance(value, dict):
-                cell_value = json.dumps(value)
-            else:
-                cell_value = str(value)
-
+            cell_value = _serialize_for_excel(col_name, value)
             cell = ws.cell(row=row_idx, column=col_idx, value=cell_value)
 
             if col_name in WRAP_COLUMNS:
@@ -149,6 +140,11 @@ def export_to_excel(
     ws.auto_filter.ref = f"A1:{get_column_letter(len(headers))}{len(df) + 1}"
 
     wb.save(output_path)
+
+    print(f"\nExcel exported to: {output_path}")
+    print(f"  Rows: {len(df)}")
+    print(f"  Columns: {len(df.columns)}")
+    print()
 
     return output_path
 
@@ -194,24 +190,13 @@ def main():
         columns = [c.strip() for c in args.columns.split(",")]
 
     try:
-        output_path = export_to_excel(
+        export_to_excel(
             parquet_path=args.parquet,
             output_path=args.output,
             columns=columns,
             status_filter=args.status,
             batch_ids=args.batch_id,
         )
-
-        df = pl.read_parquet(args.parquet)
-        if args.status:
-            df = df.filter(pl.col("status").is_in(args.status))
-        if args.batch_id:
-            df = df.filter(pl.col("batch_id").is_in(args.batch_id))
-
-        print(f"\nExcel exported to: {output_path}")
-        print(f"  Rows: {len(df)}")
-        print(f"  Columns: {len(df.columns)}")
-        print()
 
         return 0
 

--- a/scripts/try_ai_mistralsmall_script.py
+++ b/scripts/try_ai_mistralsmall_script.py
@@ -5,7 +5,10 @@
 import logging
 import os
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    plt = None
 
 from src.Clients.FFMistralSmall import FFMistralSmall as LLM
 from src.FFAI import FFAI as AI
@@ -300,13 +303,14 @@ if not history_df.is_empty():
 
     # FIX: Use a UDF (user-defined function) to calculate string length instead of the lengths() method
     try:
-        # Convert to pandas for more straightforward string length calculation
-        pd_df = history_df.to_pandas()
-        pd_df["response_length"] = pd_df["response"].str.len()
-
-        # Group by prompt_name and calculate average response length
-        response_lengths = pd_df.groupby("prompt_name")["response_length"].mean().reset_index()
-        response_lengths = response_lengths.sort_values("response_length", ascending=False)
+        response_lengths = (
+            history_df.with_columns(
+                pl.col("response").str.len_chars().alias("response_length")
+            )
+            .group_by("prompt_name")
+            .agg(pl.col("response_length").mean())
+            .sort("response_length", descending=True)
+        )
 
         logger.info("Average response length by prompt name:")
         logger.info(response_lengths)
@@ -320,30 +324,23 @@ if not history_df.is_empty():
 
     # Optional: Visualization if matplotlib is available
     try:
-        # Find the most used prompt names and their response lengths
-        pd_df = history_df.to_pandas()
-        pd_df["response_length"] = pd_df["response"].str.len()
-
-        # Filter out null prompt names and calculate average response length
         response_by_prompt = (
-            pd_df[pd_df["prompt_name"].notnull()]
-            .groupby("prompt_name")["response_length"]
-            .mean()
-            .reset_index()
+            history_df.filter(pl.col("prompt_name").is_not_null())
+            .with_columns(pl.col("response").str.len_chars().alias("response_length"))
+            .group_by("prompt_name")
+            .agg(pl.col("response_length").mean())
+            .sort("response_length", descending=True)
         )
-        response_by_prompt = response_by_prompt.sort_values("response_length", ascending=False)
 
-        if len(response_by_prompt) > 0:
-            # Create simple bar chart
+        if len(response_by_prompt) > 0 and plt is not None:
+            pdf = response_by_prompt.to_pandas()
             plt.figure(figsize=(10, 6))
-            plt.bar(response_by_prompt["prompt_name"], response_by_prompt["response_length"])
+            plt.bar(pdf["prompt_name"], pdf["response_length"])
             plt.title("Average Response Length by Prompt Name")
             plt.xlabel("Prompt Name")
             plt.ylabel("Average Response Length (chars)")
             plt.xticks(rotation=45, ha="right")
             plt.tight_layout()
-
-            # Save plot
             plt.savefig("response_length_by_prompt.png")
             logger.info("Plot saved to 'response_length_by_prompt.png'")
     except Exception as e:

--- a/src/FFAI.py
+++ b/src/FFAI.py
@@ -15,7 +15,7 @@ import logging
 import os
 import threading
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
@@ -31,6 +31,9 @@ from .core.response_result import ResponseResult
 from .core.response_utils import clean_response as _clean_response_impl
 from .core.response_utils import extract_json
 from .core.usage import TokenUsage
+
+if TYPE_CHECKING:
+    from .orchestrator.models import Interaction
 
 __all__ = ["FFAI", "extract_json_field", "interpolate_prompt"]
 
@@ -65,7 +68,7 @@ class FFAI:
         persist_dir: str | None = None,
         persist_name: str | None = None,
         auto_persist: bool = False,
-        shared_prompt_attr_history: list[dict[str, Any]] | None = None,
+        shared_prompt_attr_history: list[Interaction] | None = None,
         history_lock: threading.Lock | None = None,
     ) -> None:
         """Initialize the FFAI wrapper.
@@ -90,8 +93,8 @@ class FFAI:
         self.client = client
         self._client_history_lock = threading.Lock()
 
-        self.history: list[dict[str, Any]] = []
-        self.clean_history: list[dict[str, Any]] = []
+        self.history: list[Interaction] = []
+        self.clean_history: list[Interaction] = []
 
         self._context = ResponseContext(
             shared_prompt_attr_history=shared_prompt_attr_history,
@@ -113,12 +116,12 @@ class FFAI:
         )
 
     @property
-    def prompt_attr_history(self) -> list[dict[str, Any]]:
+    def prompt_attr_history(self) -> list[Interaction]:
         """Shared prompt attribute history (delegates to ResponseContext)."""
         return self._context.prompt_attr_history
 
     @prompt_attr_history.setter
-    def prompt_attr_history(self, value: list[dict[str, Any]]) -> None:
+    def prompt_attr_history(self, value: list[Interaction]) -> None:
         """Allow external reassignment for backward compatibility."""
         self._context.prompt_attr_history = value
 
@@ -299,15 +302,15 @@ class FFAI:
     # History accessors
     # ===========================================================================
 
-    def get_interaction_history(self) -> list[dict[str, Any]]:
+    def get_interaction_history(self) -> list[Interaction]:
         """Get complete history."""
         return self.history
 
-    def get_clean_interaction_history(self) -> list[dict[str, Any]]:
+    def get_clean_interaction_history(self) -> list[Interaction]:
         """Get complete clean history."""
         return self.clean_history
 
-    def get_prompt_attr_history(self) -> list[dict[str, Any]]:
+    def get_prompt_attr_history(self) -> list[Interaction]:
         """Get prompt attribute history."""
         return self.prompt_attr_history
 
@@ -315,7 +318,7 @@ class FFAI:
         """Get all interactions as dictionaries."""
         return self.ordered_history.get_all_interactions()
 
-    def get_latest_interaction_by_prompt_name(self, prompt_name: str) -> dict[str, Any] | None:
+    def get_latest_interaction_by_prompt_name(self, prompt_name: str) -> Interaction | None:
         """Get most recent interaction for a prompt name."""
         matching = [e for e in self.history if e.get("prompt_name") == prompt_name]
         return matching[-1] if matching else None

--- a/src/FFAI.py
+++ b/src/FFAI.py
@@ -26,6 +26,8 @@ from .core.history.permanent import PermanentHistory
 from .core.history_exporter import HistoryExporter
 from .core.prompt_builder import PromptBuilder
 from .core.prompt_utils import extract_json_field, interpolate_prompt
+from .core.response_context import ResponseContext
+from .core.response_result import ResponseResult
 from .core.response_utils import clean_response as _clean_response_impl
 from .core.response_utils import extract_json
 from .core.usage import TokenUsage
@@ -40,15 +42,18 @@ class FFAI:
 
     This class wraps an AI client implementation and adds:
     - Named prompt management for declarative context assembly
-    - Multiple history tracking mechanisms
+    - Multiple history tracking mechanisms via ``ResponseContext``
     - DataFrame export capabilities
     - Automatic persistence of history data
+
+    ``generate_response()`` returns a ``ResponseResult`` with the response
+    text, resolved prompt, token usage, and cost estimate.
 
     Attributes:
         client: The underlying AI client instance.
         history: Raw interaction history.
         clean_history: Cleaned interaction history.
-        prompt_attr_history: History indexed by prompt attributes.
+        prompt_attr_history: History indexed by prompt attributes (via ``ResponseContext``).
         ordered_history: Ordered prompt-response history.
         permanent_history: Chronological turn history.
 
@@ -83,48 +88,49 @@ class FFAI:
         os.makedirs(self.persist_dir, exist_ok=True)
 
         self.client = client
-        self._history_lock = history_lock
         self._client_history_lock = threading.Lock()
 
         self.history: list[dict[str, Any]] = []
         self.clean_history: list[dict[str, Any]] = []
 
-        if shared_prompt_attr_history is not None:
-            self.prompt_attr_history = shared_prompt_attr_history
-        else:
-            self.prompt_attr_history = []
+        self._context = ResponseContext(
+            shared_prompt_attr_history=shared_prompt_attr_history,
+            history_lock=history_lock,
+        )
 
         self.permanent_history = PermanentHistory()
         self.ordered_history = OrderedPromptHistory()
-        self.last_resolved_prompt: str | None = None
-        self._last_usage: TokenUsage | None = None
-        self._last_cost_usd: float = 0.0
 
-        self._prompt_builder = PromptBuilder(self.prompt_attr_history)
+        self._prompt_builder = PromptBuilder(self._context.prompt_attr_history)
         self._exporter = HistoryExporter(
             history=self.history,
             clean_history=self.clean_history,
-            prompt_attr_history=self.prompt_attr_history,
+            prompt_attr_history=self._context.prompt_attr_history,
             ordered_history=self.ordered_history,
             persist_dir=self.persist_dir,
             persist_name=self.persist_name,
             auto_persist=self.auto_persist,
         )
 
+    @property
+    def prompt_attr_history(self) -> list[dict[str, Any]]:
+        """Shared prompt attribute history (delegates to ResponseContext)."""
+        return self._context.prompt_attr_history
+
+    @prompt_attr_history.setter
+    def prompt_attr_history(self, value: list[dict[str, Any]]) -> None:
+        """Allow external reassignment for backward compatibility."""
+        self._context.prompt_attr_history = value
+
+    @property
+    def _history_lock(self) -> threading.Lock | None:
+        """Backward-compatible access to the history lock."""
+        return self._context.history_lock
+
     def set_client(self, client: FFAIClientBase) -> None:
         """Switch to a different AI client."""
         logger.info(f"Switching client to {client.__class__.__name__}")
         self.client = client
-
-    @property
-    def last_usage(self) -> TokenUsage | None:
-        """Token usage from the most recent generate_response() call."""
-        return self._last_usage
-
-    @property
-    def last_cost_usd(self) -> float:
-        """Estimated cost in USD from the most recent generate_response() call."""
-        return self._last_cost_usd
 
     def _extract_json(self, text: str) -> Any | None:
         """Extract JSON from text, handling markdown code blocks and JSON within first 20 chars."""
@@ -147,11 +153,20 @@ class FFAI:
         dependencies: dict | None = None,
     ) -> tuple[str, set[str]]:
         """Build the final prompt with history and variable interpolation."""
-        self._prompt_builder._prompt_attr_history = (
-            self.prompt_attr_history
-        )  # sync in case list reference changed
         result, interpolated = self._prompt_builder.build_prompt(prompt, history, dependencies)
         return result, interpolated
+
+    def build_prompt(
+        self,
+        prompt: str,
+        history: list[str] | None = None,
+        dependencies: dict | None = None,
+    ) -> tuple[str, set[str]]:
+        """Public API for prompt building (delegates to PromptBuilder).
+
+        Use this instead of the private ``_build_prompt()`` method.
+        """
+        return self._build_prompt(prompt, history, dependencies)
 
     def generate_response(
         self,
@@ -162,8 +177,13 @@ class FFAI:
         dependencies: list[str] | None = None,
         system_instructions: str | None = None,
         **kwargs: Any,
-    ) -> str:
-        """Generate response using the configured AI client."""
+    ) -> ResponseResult:
+        """Generate response using the configured AI client.
+
+        Returns:
+            ``ResponseResult`` with response, resolved prompt, usage, and cost.
+
+        """
         logger.debug(
             "\n==================================================================================="
         )
@@ -181,6 +201,9 @@ class FFAI:
         logger.debug(f"Using model: {used_model}")
 
         cleaned_response = None
+        usage: TokenUsage | None = None
+        cost_usd: float = 0.0
+        resolved_prompt: str = prompt
 
         try:
             if dependencies:
@@ -188,7 +211,7 @@ class FFAI:
                 dependencies = list(dependencies_set)
 
             final_prompt, interpolated_names = self._build_prompt(prompt, history, dependencies)
-            self.last_resolved_prompt = final_prompt
+            resolved_prompt = final_prompt
             logger.debug(f"final_prompt built: {final_prompt}")
             logger.debug(f"interpolated_names: {interpolated_names}")
 
@@ -204,17 +227,19 @@ class FFAI:
                     self.client.set_conversation_history([])
                     logger.debug("Suspended client conversation history for declarative context")
 
+            call_start = time.monotonic()
             try:
                 response = self.client.generate_response(
                     prompt=final_prompt, model=used_model, **kwargs
                 )
-                self._last_usage = getattr(self.client, "last_usage", None)
-                self._last_cost_usd = getattr(self.client, "last_cost_usd", 0.0)
             finally:
                 if should_suspend_client_history and saved_client_history is not None:
                     with self._client_history_lock:
                         self.client.set_conversation_history(saved_client_history)
                         logger.debug("Restored client conversation history")
+            call_duration_ms = (time.monotonic() - call_start) * 1000
+            usage = getattr(self.client, "last_usage", None)
+            cost_usd = getattr(self.client, "last_cost_usd", 0.0)
 
             logger.debug(f"Generated response: {response}")
 
@@ -223,14 +248,6 @@ class FFAI:
 
             self.permanent_history.add_turn_user(prompt)
             self.permanent_history.add_turn_assistant(cleaned_response)
-
-            logger.debug(f"""Adding interaction:
-                            model: {used_model}
-                            prompt: {prompt}
-                            response: {cleaned_response}
-                            prompt_name: {prompt_name}
-                            history: {history}
-            """)
 
             interaction = {
                 "prompt": prompt,
@@ -242,43 +259,9 @@ class FFAI:
             }
 
             self.history.append(interaction)
-            logger.debug(f"Added new interaction to self.history: {interaction}")
-
             self.clean_history.append(interaction)
-            logger.debug(f"Added new interaction to self.clean_history: {interaction}")
 
-            if isinstance(cleaned_response, dict):
-                logger.debug("Response was JSON.")
-                for attr, value in cleaned_response.items():
-                    logger.debug(f"Response has attribute(s). attr: {attr} | value: {value}")
-
-                    attr_interaction = {
-                        "prompt": attr,
-                        "response": value,
-                        "prompt_name": attr,
-                        "timestamp": time.time(),
-                        "model": used_model,
-                        "history": history,
-                    }
-
-                    if self._history_lock:
-                        with self._history_lock:
-                            self.prompt_attr_history.append(attr_interaction)
-                    else:
-                        self.prompt_attr_history.append(attr_interaction)
-                    logger.debug(
-                        f"Added new attr interaction to self.prompt_attr_history: {attr_interaction}"
-                    )
-            else:
-                if self._history_lock:
-                    with self._history_lock:
-                        self.prompt_attr_history.append(interaction)
-                else:
-                    self.prompt_attr_history.append(interaction)
-                logger.debug(
-                    "Interaction was not JSON, saving original 'prompt' and 'response' to prompt_attr_history."
-                )
-                logger.debug(f"Added new interaction to self.prompt_attr_history: {interaction}")
+            self._context.record(prompt, cleaned_response, used_model, prompt_name, history)
 
             self.ordered_history.add_interaction(
                 model=used_model,
@@ -288,7 +271,14 @@ class FFAI:
                 history=history,
             )
 
-            return cleaned_response
+            return ResponseResult(
+                response=cleaned_response,
+                resolved_prompt=resolved_prompt,
+                usage=usage,
+                cost_usd=cost_usd,
+                model=used_model,
+                duration_ms=round(call_duration_ms, 1),
+            )
 
         except Exception as e:
             logger.error(f"Problem with response generation: {e!s}")

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -9,6 +9,8 @@ from .history import ConversationHistory, OrderedPromptHistory, PermanentHistory
 from .history_exporter import HistoryExporter
 from .prompt_builder import PromptBuilder
 from .prompt_utils import extract_json_field, interpolate_prompt
+from .response_context import ResponseContext
+from .response_result import ResponseResult
 from .response_utils import clean_response, extract_json
 
 __all__ = [
@@ -18,6 +20,8 @@ __all__ = [
     "OrderedPromptHistory",
     "PermanentHistory",
     "PromptBuilder",
+    "ResponseContext",
+    "ResponseResult",
     "clean_response",
     "extract_json",
     "extract_json_field",

--- a/src/core/response_context.py
+++ b/src/core/response_context.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+"""Shared prompt attribute history with thread-safe recording."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class ResponseContext:
+    """Manages the shared ``prompt_attr_history`` list with thread-safe recording.
+
+    This class centralises all mutation of the shared prompt-attribute history
+    that ``PromptBuilder`` reads from for ``{{name.response}}`` interpolation.
+    It replaces the inline history recording previously scattered through
+    ``FFAI.generate_response()`` and direct list appends in
+    ``PlanningRunner`` / ``SynthesisRunner``.
+
+    Args:
+        shared_prompt_attr_history: Optional pre-existing list to share.
+            When ``None`` a new empty list is created.
+        history_lock: Optional lock for thread-safe access.
+
+    """
+
+    def __init__(
+        self,
+        shared_prompt_attr_history: list[dict[str, Any]] | None = None,
+        history_lock: threading.Lock | None = None,
+    ) -> None:
+        self.prompt_attr_history: list[dict[str, Any]] = (
+            shared_prompt_attr_history if shared_prompt_attr_history is not None else []
+        )
+        self._history_lock = history_lock
+
+    def record(
+        self,
+        prompt: str,
+        response: Any,
+        model: str,
+        prompt_name: str | None = None,
+        history: list[str] | None = None,
+    ) -> None:
+        """Record an interaction to ``prompt_attr_history``.
+
+        If *response* is a ``dict`` (JSON response from the LLM), each
+        top-level key-value pair is recorded as a separate entry so that
+        ``{{key_name.response}}`` interpolation works.
+
+        Args:
+            prompt: The original prompt text (or JSON key name).
+            response: The cleaned response (str, dict, etc.).
+            model: Model identifier used for this call.
+            prompt_name: Optional logical name for the prompt.
+            history: Optional list of history dependency names.
+
+        """
+        interaction = {
+            "prompt": prompt,
+            "response": response,
+            "prompt_name": prompt_name,
+            "timestamp": time.time(),
+            "model": model,
+            "history": history,
+        }
+
+        if isinstance(response, dict):
+            for attr, value in response.items():
+                attr_interaction = {
+                    "prompt": attr,
+                    "response": value,
+                    "prompt_name": attr,
+                    "timestamp": time.time(),
+                    "model": model,
+                    "history": history,
+                }
+                self._append(attr_interaction)
+                logger.debug(f"Added attr interaction to prompt_attr_history: {attr_interaction}")
+        else:
+            self._append(interaction)
+            logger.debug(f"Added interaction to prompt_attr_history: {interaction}")
+
+    def record_raw(
+        self,
+        interaction: dict[str, Any],
+    ) -> None:
+        """Append a pre-built interaction dict.
+
+        Used by ``PlanningRunner`` and ``SynthesisRunner`` to inject results
+        that were not produced by ``FFAI.generate_response()``.
+
+        Args:
+            interaction: A dict with at least ``prompt``, ``response``,
+                ``prompt_name`` keys.
+
+        """
+        self._append(interaction)
+
+    def clear(self) -> None:
+        """Clear the shared history list (used by synthesis phase reset)."""
+        if self._history_lock:
+            with self._history_lock:
+                self.prompt_attr_history.clear()
+        else:
+            self.prompt_attr_history.clear()
+
+    @property
+    def history_lock(self) -> threading.Lock | None:
+        """The lock used for thread-safe history access."""
+        return self._history_lock
+
+    def _append(self, interaction: dict[str, Any]) -> None:
+        if self._history_lock:
+            with self._history_lock:
+                self.prompt_attr_history.append(interaction)
+        else:
+            self.prompt_attr_history.append(interaction)

--- a/src/core/response_result.py
+++ b/src/core/response_result.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+"""Structured return type for FFAI response generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .usage import TokenUsage
+
+
+@dataclass
+class ResponseResult:
+    """Structured result from an FFAI response generation call.
+
+    Replaces side-channel attributes (``last_usage``, ``last_cost_usd``,
+    ``last_resolved_prompt``) with a single typed return value.
+
+    Attributes:
+        response: The cleaned AI response (str, dict, list, etc.).
+        resolved_prompt: The fully interpolated prompt sent to the model.
+        usage: Token usage from the API call, if available.
+        cost_usd: Estimated cost in USD for this call.
+        model: Model identifier used for this call.
+        duration_ms: Wall-clock duration of the LLM call in milliseconds.
+
+    """
+
+    response: Any
+    resolved_prompt: str = ""
+    usage: TokenUsage | None = None
+    cost_usd: float = 0.0
+    model: str = ""
+    duration_ms: float = 0.0

--- a/src/orchestrator/agent_executor.py
+++ b/src/orchestrator/agent_executor.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from ..config import get_config
 from ..FFAI import FFAI
+from .models import ConfigSpec, PromptSpec
 from .results import ResultBuilder
 from .tool_registry import ToolRegistry
 
@@ -49,8 +50,8 @@ class AgentExecutor:
     def __init__(
         self,
         tool_registry: ToolRegistry,
-        config: dict[str, Any],
-        record_history_fn: Callable[[dict[str, Any], str | None], None],
+        config: ConfigSpec,
+        record_history_fn: Callable[[PromptSpec, str | None], None],
     ) -> None:
         self.tool_registry = tool_registry
         self.config = config
@@ -58,11 +59,11 @@ class AgentExecutor:
 
     def execute(
         self,
-        prompt: dict[str, Any],
+        prompt: PromptSpec,
         ffai: FFAI,
         builder: ResultBuilder,
         seq_label: str,
-        inject_references_fn: Callable[[dict[str, Any]], str],
+        inject_references_fn: Callable[[PromptSpec], str],
         get_isolated_ffai_fn: Callable[[str | None], FFAI],
     ) -> dict[str, Any] | None:
         """Execute a prompt using the agentic tool-call loop.
@@ -181,7 +182,7 @@ class AgentExecutor:
 
     def validate_response(
         self,
-        prompt: dict[str, Any],
+        prompt: PromptSpec,
         builder: Any,
         agent_result: Any,
         tool_names: list[str],

--- a/src/orchestrator/agent_executor.py
+++ b/src/orchestrator/agent_executor.py
@@ -97,12 +97,11 @@ class AgentExecutor:
         agent_config = get_config().agent
 
         injected_prompt = inject_references_fn(prompt)
-        resolved_prompt, _ = ffai._build_prompt(
+        resolved_prompt, _ = ffai.build_prompt(
             injected_prompt,
             prompt.get("history"),
             None,
         )
-        ffai.last_resolved_prompt = resolved_prompt
 
         logger.info(f"{seq_label} agent mode: {len(tool_names)} tool(s), max_rounds={max_rounds}")
 
@@ -226,7 +225,7 @@ class AgentExecutor:
         for attempt in range(1, max_val_retries + 2):
             try:
                 val_client = get_isolated_ffai_fn(prompt.get("client"))
-                val_response = val_client.generate_response(
+                val_result = val_client.generate_response(
                     validation_prompt_text,
                     prompt_name=f"{prompt.get('prompt_name', '')}_validation",
                     model=self.config.get("model"),
@@ -244,7 +243,11 @@ class AgentExecutor:
                     return
                 continue
 
-            val_response = val_response.strip()
+            val_response = (
+                val_result.response.strip()
+                if isinstance(val_result.response, str)
+                else str(val_result.response).strip()
+            )
 
             if re.match(r"^PASS\s*$", val_response, re.IGNORECASE):
                 logger.info(

--- a/src/orchestrator/base/orchestrator_base.py
+++ b/src/orchestrator/base/orchestrator_base.py
@@ -36,8 +36,9 @@ from ..document_processor import DocumentProcessor
 from ..document_registry import DocumentRegistry
 from ..executor import Executor
 from ..graph import build_execution_graph, evaluate_condition, get_ready_prompts
+from ..models import ConfigSpec, DocumentSpec, Interaction, PromptSpec
 from ..planning_runner import PlanningPhaseRunner
-from ..results import ResultBuilder
+from ..results import ResultBuilder, ResultsFrame
 from ..scoring import ScoringRubric
 from ..state import ExecutionState, PromptNode
 from ..synthesis_runner import SynthesisRunner
@@ -115,8 +116,8 @@ class OrchestratorBase(ABC):
 
         self.progress_callback = progress_callback
 
-        self.config: dict[str, Any] = {}
-        self.prompts: list[dict[str, Any]] = []
+        self.config: ConfigSpec = {}
+        self.prompts: list[PromptSpec] = []
         self.results: list[dict[str, Any]] = []
 
         # FFAI wrapper around the default client. Created by _init_client() and
@@ -125,7 +126,7 @@ class OrchestratorBase(ABC):
         # own client state.
         self.ffai: FFAI | None = None
 
-        self.shared_prompt_attr_history: list[dict[str, Any]] = []
+        self.shared_prompt_attr_history: list[Interaction] = []
         self.history_lock = threading.Lock()
         self._response_context = ResponseContext(
             shared_prompt_attr_history=self.shared_prompt_attr_history,
@@ -155,7 +156,20 @@ class OrchestratorBase(ABC):
         # Planning phase state
         self.planning_results: list[dict[str, Any]] = []
         self.has_planning: bool = False
-        self.planning_prompts: list[dict[str, Any]] = []
+        self.planning_prompts: list[PromptSpec] = []
+
+        self._results_frame: ResultsFrame | None = None
+
+    @property
+    def results_frame(self) -> ResultsFrame:
+        """Lazily-built ResultsFrame wrapping self.results.
+
+        Invalidated whenever self.results is reassigned.
+        """
+        if self._results_frame is None:
+            all_results = list(self.planning_results) + list(self.results)
+            self._results_frame = ResultsFrame(all_results)
+        return self._results_frame
 
     @property
     @abstractmethod
@@ -209,7 +223,7 @@ class OrchestratorBase(ABC):
 
     def _init_documents(
         self,
-        documents_data: list[dict[str, Any]],
+        documents_data: list[DocumentSpec],
         workbook_dir: str,
     ) -> None:
         """Initialize document processor and registry for document references.
@@ -326,7 +340,7 @@ class OrchestratorBase(ABC):
     def _get_isolated_ffai(
         self,
         client_name: str | None = None,
-        batch_history: list[dict[str, Any]] | None = None,
+        batch_history: list[Interaction] | None = None,
         batch_history_lock: threading.Lock | None = None,
     ) -> FFAI:
         """Create an FFAI instance with isolated client and scoped history.
@@ -358,9 +372,9 @@ class OrchestratorBase(ABC):
 
     def _record_to_history(
         self,
-        history: list[dict[str, Any]],
+        history: list[Interaction],
         lock: threading.Lock | None,
-        prompt: dict[str, Any],
+        prompt: PromptSpec,
         response: str | None,
     ) -> None:
         """Record an interaction to a specific history list.
@@ -399,7 +413,7 @@ class OrchestratorBase(ABC):
         """
         self._validation_manager.validate(self)
 
-    def _inject_references(self, prompt: dict[str, Any]) -> str:
+    def _inject_references(self, prompt: PromptSpec) -> str:
         """Inject document references or semantic search results into a prompt.
 
         Args:
@@ -497,7 +511,7 @@ class OrchestratorBase(ABC):
         return get_ready_prompts(state, nodes)
 
     def _evaluate_condition(
-        self, prompt: dict[str, Any], results_by_name: dict[str, dict[str, Any]]
+        self, prompt: PromptSpec, results_by_name: dict[str, dict[str, Any]]
     ) -> tuple[bool, str | None, str | None]:
         """Evaluate a prompt's condition.
 
@@ -507,7 +521,7 @@ class OrchestratorBase(ABC):
         return evaluate_condition(prompt, results_by_name)
 
     def _evaluate_condition_with_trace(
-        self, prompt: dict[str, Any], results_by_name: dict[str, dict[str, Any]]
+        self, prompt: PromptSpec, results_by_name: dict[str, dict[str, Any]]
     ) -> tuple[bool, str | None, str | None, str | None]:
         """Evaluate a prompt's condition and return the resolved trace."""
         from ..graph import evaluate_condition_with_trace
@@ -516,11 +530,11 @@ class OrchestratorBase(ABC):
 
     def _execute_agent_mode(
         self,
-        prompt: dict[str, Any],
+        prompt: PromptSpec,
         ffai: FFAI,
         builder: Any,
         seq_label: str,
-        batch_history: list[dict[str, Any]] | None = None,
+        batch_history: list[Interaction] | None = None,
         batch_history_lock: threading.Lock | None = None,
     ) -> dict[str, Any]:
         """Execute a prompt using the agentic tool-call loop.
@@ -566,12 +580,12 @@ class OrchestratorBase(ABC):
 
     def _execute_with_retry(
         self,
-        prompt: dict[str, Any],
+        prompt: PromptSpec,
         results_by_name: dict[str, dict[str, Any]],
         results_lock: threading.Lock | None = None,
         batch_id: int | None = None,
         batch_name: str | None = None,
-        batch_history: list[dict[str, Any]] | None = None,
+        batch_history: list[Interaction] | None = None,
         batch_history_lock: threading.Lock | None = None,
     ) -> dict[str, Any]:
         """Execute a prompt with retry logic, supporting both regular and batch execution.
@@ -721,7 +735,7 @@ class OrchestratorBase(ABC):
 
     def _execute_prompt_core(
         self,
-        prompt: dict[str, Any],
+        prompt: PromptSpec,
         results_by_name: dict[str, dict[str, Any]],
         results_lock: threading.Lock | None = None,
     ) -> dict[str, Any]:
@@ -740,9 +754,7 @@ class OrchestratorBase(ABC):
         """
         return self._execute_with_retry(prompt, results_by_name, results_lock)
 
-    def _execute_prompt_isolated(
-        self, prompt: dict[str, Any], state: ExecutionState
-    ) -> dict[str, Any]:
+    def _execute_prompt_isolated(self, prompt: PromptSpec, state: ExecutionState) -> dict[str, Any]:
         """Execute a single prompt with completely isolated client clone.
 
         Used by the parallel executor. Delegates to _execute_prompt_core with
@@ -764,7 +776,7 @@ class OrchestratorBase(ABC):
 
     def _execute_prompt(
         self,
-        prompt: dict[str, Any],
+        prompt: PromptSpec,
         results_by_name: dict[str, dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Execute a single prompt with retry logic.
@@ -788,9 +800,7 @@ class OrchestratorBase(ABC):
         """Replace {{variable}} placeholders with values from data row."""
         return resolve_variables(text, data_row)
 
-    def _resolve_prompt_variables(
-        self, prompt: dict[str, Any], data_row: dict[str, Any]
-    ) -> dict[str, Any]:
+    def _resolve_prompt_variables(self, prompt: PromptSpec, data_row: dict[str, Any]) -> PromptSpec:
         """Resolve all {{variable}} placeholders in a prompt."""
         return resolve_prompt_variables(prompt, data_row)
 
@@ -803,7 +813,7 @@ class OrchestratorBase(ABC):
         batch_id: int,
         data_row: dict[str, Any],
         batch_name: str,
-        batch_history: list[dict[str, Any]] | None = None,
+        batch_history: list[Interaction] | None = None,
         batch_history_lock: threading.Lock | None = None,
     ) -> list[dict[str, Any]]:
         """Execute all prompts for a single batch with resolved variables.
@@ -848,11 +858,11 @@ class OrchestratorBase(ABC):
 
     def _execute_prompt_with_batch(
         self,
-        prompt: dict[str, Any],
+        prompt: PromptSpec,
         batch_id: int,
         batch_name: str,
         results_by_name: dict[str, dict[str, Any]] | None = None,
-        batch_history: list[dict[str, Any]] | None = None,
+        batch_history: list[Interaction] | None = None,
         batch_history_lock: threading.Lock | None = None,
     ) -> dict[str, Any]:
         """Execute a single prompt and tag with batch info.
@@ -946,7 +956,7 @@ class OrchestratorBase(ABC):
     def _resolve_shared_document(
         document_path: str,
         reference_name: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> DocumentSpec:
         """Create a document definition for a shared document file.
 
         Args:
@@ -992,7 +1002,7 @@ class OrchestratorBase(ABC):
         """
         from ..discovery import create_data_rows_from_documents, discover_documents
 
-        discovered_docs: list[dict[str, Any]] = []
+        discovered_docs: list[DocumentSpec] = []
 
         if self._shared_document_path:
             shared_doc = self._resolve_shared_document(
@@ -1129,6 +1139,7 @@ class OrchestratorBase(ABC):
                         self.results = self.execute_parallel()
                     else:
                         self.results = self.execute()
+                self._results_frame = None
 
             if self.has_scoring:
                 self._aggregate_scores()
@@ -1169,68 +1180,9 @@ class OrchestratorBase(ABC):
         if not self.results:
             return {"status": "not_run"}
 
-        summary: dict[str, Any] = {
-            "total_prompts": len(self.results),
-            "successful": sum(1 for r in self.results if r["status"] == "success"),
-            "failed": sum(1 for r in self.results if r["status"] == "failed"),
-            "skipped": sum(1 for r in self.results if r["status"] == "skipped"),
-            "total_attempts": sum(r["attempts"] for r in self.results),
-        }
-
-        total_input = sum(r.get("input_tokens", 0) for r in self.results)
-        total_output = sum(r.get("output_tokens", 0) for r in self.results)
-        total_tokens = sum(r.get("total_tokens", 0) for r in self.results)
-        total_cost = sum(r.get("cost_usd", 0.0) for r in self.results)
-        if total_tokens > 0 or total_cost > 0:
-            summary["tokens"] = {
-                "input": total_input,
-                "output": total_output,
-                "total": total_tokens,
-            }
-            summary["cost_usd"] = round(total_cost, 6)
-
-        condition_count = sum(1 for r in self.results if r.get("condition"))
-        if condition_count > 0:
-            summary["prompts_with_conditions"] = condition_count
-
-        if self.is_batch_mode:
-            batch_ids = {r.get("batch_id", 0) for r in self.results}
-            summary["total_batches"] = len(batch_ids)
-            summary["batch_mode"] = True
-
-            batch_failures: dict[int, int] = {}
-            for r in self.results:
-                if r["status"] == "failed":
-                    batch_id = r.get("batch_id", 0)
-                    batch_failures[batch_id] = batch_failures.get(batch_id, 0) + 1
-            if batch_failures:
-                summary["batches_with_failures"] = batch_failures
-
-        if self.has_scoring:
-            scored = [r for r in self.results if r.get("scoring_status")]
-            scoring_block: dict[str, Any] = {
-                "total_scored": len(scored),
-                "ok": sum(1 for r in scored if r["scoring_status"] == "ok"),
-                "partial": sum(1 for r in scored if r["scoring_status"] == "partial"),
-                "failed": sum(1 for r in scored if r["scoring_status"] == "failed"),
-                "skipped": sum(1 for r in scored if r["scoring_status"] == "skipped"),
-                "strategy": self.evaluation_strategy,
-            }
-            composites = [
-                r["composite_score"] for r in scored if r.get("composite_score") is not None
-            ]
-            if composites:
-                scoring_block["avg_composite"] = round(sum(composites) / len(composites), 2)
-                scoring_block["max_composite"] = max(composites)
-                scoring_block["min_composite"] = min(composites)
-            summary["scoring"] = scoring_block
-
-        if self.has_synthesis:
-            synth = [r for r in self.results if r.get("result_type") == "synthesis"]
-            summary["synthesis"] = {
-                "count": len(synth),
-                "successful": sum(1 for r in synth if r["status"] == "success"),
-                "failed": sum(1 for r in synth if r["status"] == "failed"),
-            }
-
-        return summary
+        return ResultsFrame(self.results).summary(
+            is_batch_mode=self.is_batch_mode,
+            evaluation_strategy=self.evaluation_strategy,
+            has_scoring=self.has_scoring,
+            has_synthesis=self.has_synthesis,
+        )

--- a/src/orchestrator/base/orchestrator_base.py
+++ b/src/orchestrator/base/orchestrator_base.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 
 from ...config import get_config
 from ...core.client_base import FFAIClientBase
+from ...core.response_context import ResponseContext
 from ...FFAI import FFAI
 from ...observability import get_telemetry_manager
 from ..agent_executor import AgentExecutor
@@ -126,6 +127,10 @@ class OrchestratorBase(ABC):
 
         self.shared_prompt_attr_history: list[dict[str, Any]] = []
         self.history_lock = threading.Lock()
+        self._response_context = ResponseContext(
+            shared_prompt_attr_history=self.shared_prompt_attr_history,
+            history_lock=self.history_lock,
+        )
 
         self.batch_data: list[dict[str, Any]] = []
         self.is_batch_mode: bool = False
@@ -339,7 +344,11 @@ class OrchestratorBase(ABC):
             client = self.client_registry.clone(client_name)
         else:
             client = self.client.clone()
-        history = batch_history if batch_history is not None else self.shared_prompt_attr_history
+        history = (
+            batch_history
+            if batch_history is not None
+            else self._response_context.prompt_attr_history
+        )
         lock = batch_history_lock if batch_history_lock is not None else self.history_lock
         return FFAI(
             client,
@@ -661,7 +670,7 @@ class OrchestratorBase(ABC):
                     injected_prompt = self._inject_references(prompt)
 
                     call_start = time.monotonic()
-                    response = ffai.generate_response(
+                    result = ffai.generate_response(
                         prompt=injected_prompt,
                         prompt_name=prompt.get("prompt_name"),
                         history=prompt.get("history"),
@@ -671,21 +680,23 @@ class OrchestratorBase(ABC):
                     )
                     call_duration_ms = (time.monotonic() - call_start) * 1000
 
-                    builder.with_resolved_prompt(ffai.last_resolved_prompt or injected_prompt)
-                    builder.with_response(response)
+                    builder.with_resolved_prompt(result.resolved_prompt or injected_prompt)
+                    builder.with_response(result.response)
                     builder.with_duration(call_duration_ms)
 
-                    usage = getattr(ffai, "last_usage", None)
-                    if usage:
+                    if result.usage:
                         builder.with_usage(
-                            usage.input_tokens, usage.output_tokens, usage.total_tokens
+                            result.usage.input_tokens,
+                            result.usage.output_tokens,
+                            result.usage.total_tokens,
                         )
-                        prompt_span.set_attribute("prompt.input_tokens", usage.input_tokens)
-                        prompt_span.set_attribute("prompt.output_tokens", usage.output_tokens)
-                        prompt_span.set_attribute("prompt.total_tokens", usage.total_tokens)
-                    cost_usd = getattr(ffai, "last_cost_usd", 0.0)
-                    builder.with_cost(cost_usd)
-                    prompt_span.set_attribute("prompt.cost_usd", cost_usd)
+                        prompt_span.set_attribute("prompt.input_tokens", result.usage.input_tokens)
+                        prompt_span.set_attribute(
+                            "prompt.output_tokens", result.usage.output_tokens
+                        )
+                        prompt_span.set_attribute("prompt.total_tokens", result.usage.total_tokens)
+                    builder.with_cost(result.cost_usd)
+                    prompt_span.set_attribute("prompt.cost_usd", result.cost_usd)
                     prompt_span.set_attribute("prompt.duration_ms", call_duration_ms)
                     prompt_span.set_attribute("prompt.status", "success")
                     prompt_span.set_attribute("prompt.attempts", attempt)

--- a/src/orchestrator/discovery.py
+++ b/src/orchestrator/discovery.py
@@ -20,6 +20,7 @@ from typing import Any
 from openpyxl import Workbook
 
 from ..config import get_config
+from .models import DocumentSpec
 from .workbook_formatter import WorkbookFormatter
 from .workbook_parser import WorkbookParser
 
@@ -70,7 +71,7 @@ def discover_documents(
     extensions: set[str] | None = None,
     tags: list[str] | None = None,
     absolute_paths: bool = False,
-) -> list[dict[str, Any]]:
+) -> list[DocumentSpec]:
     """Scan a folder for documents and return definitions matching DOCUMENTS_HEADERS.
 
     Files are sorted alphabetically by filename stem. Unsupported file
@@ -98,7 +99,7 @@ def discover_documents(
     exts = extensions or DEFAULT_EXTENSIONS
     tags_str = ", ".join(tags) if tags else ""
 
-    document_defs: list[dict[str, Any]] = []
+    document_defs: list[DocumentSpec] = []
     for filepath in sorted(folder.iterdir()):
         if not filepath.is_file():
             continue
@@ -137,7 +138,7 @@ def discover_documents(
 
 
 def create_data_rows_from_documents(
-    document_defs: list[dict[str, Any]],
+    document_defs: list[DocumentSpec],
     documents_column: str = "_documents",
     name_column: str = "candidate_name",
 ) -> list[dict[str, Any]]:
@@ -179,7 +180,7 @@ def create_data_rows_from_documents(
 def create_evaluation_workbook(
     output_path: str | Path,
     documents_folder: str | Path,
-    shared_documents: list[dict[str, Any]] | None = None,
+    shared_documents: list[DocumentSpec] | None = None,
     evaluation_strategy: str = "balanced",
     extensions: set[str] | None = None,
     tags: list[str] | None = None,

--- a/src/orchestrator/document_registry.py
+++ b/src/orchestrator/document_registry.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .document_processor import DocumentProcessor
+from .models import DocumentSpec
 
 if TYPE_CHECKING:
     from ..RAG import FFRAGClient
@@ -43,7 +44,7 @@ class DocumentRegistry:
 
     def __init__(
         self,
-        documents: list[dict[str, Any]],
+        documents: list[DocumentSpec],
         processor: DocumentProcessor,
         workbook_dir: str,
         rag_client: FFRAGClient | None = None,
@@ -118,7 +119,7 @@ class DocumentRegistry:
         """Get all registered reference names."""
         return set(self.documents.keys())
 
-    def get_document_config(self, reference_name: str) -> dict[str, Any] | None:
+    def get_document_config(self, reference_name: str) -> DocumentSpec | None:
         """Get the configuration for a document by reference name."""
         return self.documents.get(reference_name)
 

--- a/src/orchestrator/excel_orchestrator.py
+++ b/src/orchestrator/excel_orchestrator.py
@@ -221,7 +221,6 @@ class ExcelOrchestrator(OrchestratorBase):
         """
         batch_output = self.config.get("batch_output", "combined")
 
-        # Include planning results in the combined results list
         all_results = list(self.planning_results) + list(results)
 
         if self.is_batch_mode and batch_output == "separate_sheets":
@@ -264,14 +263,12 @@ class ExcelOrchestrator(OrchestratorBase):
         """
         sheet_names: list[str] = []
 
-        # Write planning results to a separate sheet if present
         if self.planning_results:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             planning_sheet = f"planning_{timestamp}"
             self.builder.write_results(self.planning_results, planning_sheet)
             sheet_names.append(planning_sheet)
 
-        # Filter out planning results from batch grouping
         batches: dict[int, list[dict[str, Any]]] = {}
         for result in self.results:
             if result.get("result_type") == "planning":

--- a/src/orchestrator/explain.py
+++ b/src/orchestrator/explain.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .graph import ExecutionGraph, build_execution_graph_with_edges
+from .models import PromptSpec
 
 
 @dataclass
@@ -30,7 +31,7 @@ class LevelGroup:
     """Prompts grouped by execution level."""
 
     level: int
-    prompts: list[dict[str, Any]] = field(default_factory=list)
+    prompts: list[PromptSpec] = field(default_factory=list)
 
 
 @dataclass
@@ -56,7 +57,7 @@ class ExplainPlan:
 
 
 def build_explain_plan(
-    prompts: list[dict[str, Any]],
+    prompts: list[PromptSpec],
     *,
     batch_data: list[dict[str, Any]] | None = None,
 ) -> ExplainPlan:
@@ -246,7 +247,7 @@ def _format_edges(plan: ExplainPlan) -> str:
 
 
 def format_prompt_preview(
-    prompt: dict[str, Any],
+    prompt: PromptSpec,
     *,
     batch_row: dict[str, Any] | None = None,
     upstream_results: dict[str, dict[str, Any]] | None = None,

--- a/src/orchestrator/graph.py
+++ b/src/orchestrator/graph.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .condition_evaluator import ConditionEvaluator
+from .models import PromptSpec
 from .state import ExecutionState, PromptNode
 
 
@@ -53,7 +54,7 @@ class ExecutionGraph:
 
 
 def build_execution_graph(
-    prompts: list[dict[str, Any]],
+    prompts: list[PromptSpec],
 ) -> dict[int, PromptNode]:
     """Build dependency graph for parallel execution.
 
@@ -76,7 +77,7 @@ def build_execution_graph(
 
 
 def build_execution_graph_with_edges(
-    prompts: list[dict[str, Any]],
+    prompts: list[PromptSpec],
 ) -> ExecutionGraph:
     """Build execution graph with full edge source metadata.
 
@@ -188,7 +189,7 @@ def get_ready_prompts(state: ExecutionState, nodes: dict[int, PromptNode]) -> li
 
 
 def evaluate_condition(
-    prompt: dict[str, Any],
+    prompt: PromptSpec,
     results_by_name: dict[str, dict[str, Any]],
 ) -> tuple[bool, str | None, str | None]:
     """Evaluate a prompt's condition.
@@ -213,7 +214,7 @@ def evaluate_condition(
 
 
 def evaluate_condition_with_trace(
-    prompt: dict[str, Any],
+    prompt: PromptSpec,
     results_by_name: dict[str, dict[str, Any]],
 ) -> tuple[bool, str | None, str | None, str | None]:
     """Evaluate a prompt's condition and return the resolved trace.

--- a/src/orchestrator/manifest.py
+++ b/src/orchestrator/manifest.py
@@ -23,13 +23,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import polars as pl
 import yaml
 
 from ..config import get_config
 from ..core.client_base import FFAIClientBase
 from .base import OrchestratorBase
-from .workbook_parser import WorkbookParser, _serialize_result_value
+from .models import ConfigSpec, DocumentSpec, PromptSpec
+from .results import ResultsFrame
+from .workbook_parser import WorkbookParser
 
 logger = logging.getLogger(__name__)
 
@@ -158,12 +159,12 @@ class WorkbookManifestExporter:
         with open(manifest_path / "manifest.yaml", "w", encoding="utf-8") as f:
             yaml.dump(manifest_data, f, default_flow_style=False, sort_keys=False)
 
-    def _write_config_yaml(self, manifest_path: Path, config: dict[str, Any]) -> None:
+    def _write_config_yaml(self, manifest_path: Path, config: ConfigSpec) -> None:
         """Write configuration to YAML file."""
         with open(manifest_path / "config.yaml", "w", encoding="utf-8") as f:
             yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 
-    def _write_prompts_yaml(self, manifest_path: Path, prompts: list[dict[str, Any]]) -> None:
+    def _write_prompts_yaml(self, manifest_path: Path, prompts: list[PromptSpec]) -> None:
         """Write prompts to YAML file."""
         prompts_data = {"prompts": []}
 
@@ -221,7 +222,7 @@ class WorkbookManifestExporter:
         with open(manifest_path / "clients.yaml", "w", encoding="utf-8") as f:
             yaml.dump(clients_yaml, f, default_flow_style=False, sort_keys=False)
 
-    def _write_documents_yaml(self, manifest_path: Path, documents: list[dict[str, Any]]) -> None:
+    def _write_documents_yaml(self, manifest_path: Path, documents: list[DocumentSpec]) -> None:
         """Write document references to YAML file."""
         docs_yaml = {"documents": documents}
         with open(manifest_path / "documents.yaml", "w", encoding="utf-8") as f:
@@ -369,7 +370,7 @@ class ManifestOrchestrator(OrchestratorBase):
 
     def _init_documents(
         self,
-        documents_data: list[dict[str, Any]] | None = None,
+        documents_data: list[DocumentSpec] | None = None,
         workbook_dir: str | None = None,
     ) -> None:
         """Initialize documents from manifest (backward compatibility wrapper).
@@ -545,6 +546,9 @@ class ManifestOrchestrator(OrchestratorBase):
     def _write_results(self, results: list[dict[str, Any]]) -> str:
         """Write results to a parquet file.
 
+        Includes planning results (fixes previous omission) and delegates
+        serialization to ResultsFrame.
+
         Args:
             results: List of result dictionaries.
 
@@ -556,43 +560,16 @@ class ManifestOrchestrator(OrchestratorBase):
         manifest_name = self._get_manifest_name()
         output_prompts = self._get_output_prompts()
 
-        rows = []
-        for r in results:
-            row = {
-                header: _serialize_result_value(header, r.get(header))
-                for header in WorkbookParser.RESULTS_HEADERS
-            }
-            rows.append(row)
+        all_results = list(self.planning_results) + list(results)
+        frame = ResultsFrame(all_results)
 
-        try:
-            df = pl.DataFrame(rows)
-        except pl.ComputeError:
-            logger.warning(
-                "Polars schema inference failed, falling back to full scan. "
-                "This may happen when result rows have mixed types "
-                "(e.g., batch + synthesis results with different null patterns)."
-            )
-            df = pl.DataFrame(rows, infer_schema_length=None)
-
-        import pyarrow.parquet as pq
-
-        # Add manifest metadata as parquet key-value metadata
-        manifest_meta = {
-            b"manifest_name": manifest_name.encode("utf-8"),
-            b"output_prompts": json.dumps(output_prompts).encode("utf-8"),
-            b"source_workbook": (self._source_workbook or "").encode("utf-8"),
+        metadata = {
+            "manifest_name": manifest_name,
+            "output_prompts": json.dumps(output_prompts),
+            "source_workbook": self._source_workbook or "",
         }
 
-        # Convert to Arrow table and add metadata
-        table = df.to_arrow()
-        existing_meta = dict(table.schema.metadata or {})
-        existing_meta.update(manifest_meta)
-        table = table.replace_schema_metadata(existing_meta)
-
-        pq.write_table(table, output_path)
-
-        logger.info(f"Results written to parquet: {output_path}")
-        return str(output_path)
+        return frame.to_parquet(output_path, metadata=metadata)
 
     def _write_parquet(self, results: list[dict[str, Any]]) -> str:
         """Write results to a parquet file (backward compatibility wrapper).

--- a/src/orchestrator/models.py
+++ b/src/orchestrator/models.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+"""Typed domain models for orchestrator pipeline data shapes.
+
+These TypedDict definitions document the dict shapes that flow through the
+orchestrator pipeline. They are runtime-transparent (no behavioral change)
+and serve static analysis, IDE autocomplete, and developer documentation.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class PromptSpec(TypedDict, total=False):
+    sequence: int
+    prompt_name: str
+    prompt: str
+    history: list[str] | None
+    notes: str | None
+    client: str | None
+    condition: str | None
+    references: list[str] | None
+    semantic_query: str | None
+    semantic_filter: str | None
+    query_expansion: str | None
+    rerank: str | None
+    agent_mode: bool
+    tools: list[str] | None
+    max_tool_rounds: int | None
+    validation_prompt: str | None
+    max_validation_retries: int | None
+    phase: str
+    generator: bool
+    _generated: bool
+    _generated_by: str
+
+
+class Interaction(TypedDict, total=False):
+    prompt: str
+    response: str
+    prompt_name: str | None
+    timestamp: float
+    model: str | None
+    history: list[str] | None
+
+
+class ConfigSpec(TypedDict, total=False):
+    name: str
+    description: str
+    client_type: str
+    model: str
+    api_key_env: str
+    max_retries: int
+    temperature: float
+    max_tokens: int
+    system_instructions: str
+    created_at: str
+    evaluation_strategy: str
+    batch_mode: str
+    batch_output: str
+    on_batch_error: str
+
+
+class DocumentSpec(TypedDict, total=False):
+    reference_name: str
+    common_name: str
+    file_path: str
+    tags: str
+    chunking_strategy: str
+    notes: str
+
+
+class Message(TypedDict, total=False):
+    role: str
+    content: str
+    tool_call_id: str

--- a/src/orchestrator/planning.py
+++ b/src/orchestrator/planning.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from json_repair import loads as json_repair_loads
 
+from .models import PromptSpec
 from .scoring import ScoringCriteria
 
 logger = logging.getLogger(__name__)
@@ -253,7 +254,7 @@ class PlanningArtifactParser:
 
     def validate_prompts(
         self,
-        prompts: list[dict[str, Any]],
+        prompts: list[PromptSpec],
         existing_names: set[str],
         doc_refs: set[str],
         batch_keys: set[str],
@@ -331,11 +332,11 @@ class PlanningArtifactParser:
 
     def assign_sequences(
         self,
-        prompts: list[dict[str, Any]],
+        prompts: list[PromptSpec],
         existing_sequences: set[int],
         base: str | int = "auto",
         step: int = 10,
-    ) -> list[dict[str, Any]]:
+    ) -> list[PromptSpec]:
         """Assign sequence numbers to generated prompts.
 
         When base="auto": uses max(existing_sequences) rounded up to

--- a/src/orchestrator/planning_runner.py
+++ b/src/orchestrator/planning_runner.py
@@ -109,17 +109,16 @@ class PlanningPhaseRunner:
 
             if prompt.get("generator") and result.get("status") == "success":
                 response = result.get("response", "")
-                with orchestrator.history_lock:
-                    orchestrator.shared_prompt_attr_history.append(
-                        {
-                            "prompt": prompt.get("prompt", ""),
-                            "response": response,
-                            "prompt_name": prompt.get("prompt_name"),
-                            "timestamp": time.time(),
-                            "model": orchestrator.config.get("model"),
-                            "history": prompt.get("history"),
-                        }
-                    )
+                orchestrator._response_context.record_raw(
+                    {
+                        "prompt": prompt.get("prompt", ""),
+                        "response": response,
+                        "prompt_name": prompt.get("prompt_name"),
+                        "timestamp": time.time(),
+                        "model": orchestrator.config.get("model"),
+                        "history": prompt.get("history"),
+                    }
+                )
 
                 try:
                     artifact = parser.parse(response, prompt_name)

--- a/src/orchestrator/results/__init__.py
+++ b/src/orchestrator/results/__init__.py
@@ -5,6 +5,7 @@
 """Result handling for orchestrator execution."""
 
 from .builder import ResultBuilder
+from .frame import ResultsFrame
 from .result import PromptResult
 
-__all__ = ["PromptResult", "ResultBuilder"]
+__all__ = ["PromptResult", "ResultBuilder", "ResultsFrame"]

--- a/src/orchestrator/results/builder.py
+++ b/src/orchestrator/results/builder.py
@@ -250,16 +250,16 @@ class ResultBuilder:
 
     def with_scoring(
         self,
-        scores: dict[str, Any],
-        composite_score: float,
+        scores: dict[str, Any] | None,
+        composite_score: float | None,
         scoring_status: str,
         strategy: str,
     ) -> ResultBuilder:
         """Set scoring results.
 
         Args:
-            scores: Dictionary of criteria_name to score values.
-            composite_score: Weighted composite score.
+            scores: Dictionary of criteria_name to score values, or None.
+            composite_score: Weighted composite score, or None.
             scoring_status: Aggregation status (ok, partial, failed, skipped).
             strategy: Evaluation strategy used.
 

--- a/src/orchestrator/results/frame.py
+++ b/src/orchestrator/results/frame.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+"""Polars DataFrame wrapper for orchestrator results.
+
+Provides a single point of conversion from list[dict] results to a typed
+DataFrame, with convenience methods for summarization, pivoting, and parquet
+output.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from dataclasses import fields as dataclass_fields
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+from .result import PromptResult
+
+logger = logging.getLogger(__name__)
+
+JSON_SERIALIZE_COLUMNS = frozenset(
+    {"history", "references", "tool_calls", "scores", "extraction_trace"}
+)
+
+
+def _deserialize_json_columns(
+    rows: list[dict[str, Any]], columns: frozenset[str] | None = None
+) -> list[dict[str, Any]]:
+    """Parse JSON-serialized columns back to native Python objects.
+
+    Used when converting DataFrame rows back to dicts for code that
+    expects native types (e.g., synthesis sorting and context formatting).
+    """
+    cols = columns or JSON_SERIALIZE_COLUMNS
+    for row in rows:
+        for col in cols:
+            val = row.get(col)
+            if isinstance(val, str):
+                with contextlib.suppress(json.JSONDecodeError, TypeError):
+                    row[col] = json.loads(val)
+    return rows
+
+
+RESULTS_COLUMNS: list[str] = [f.name for f in dataclass_fields(PromptResult)]
+
+PIVOT_COLUMNS = [
+    "batch_name",
+    "criteria_name",
+    "normalized_score",
+    "weight",
+    "weighted_score",
+    "rank",
+    "percentile",
+    "scale_min",
+    "scale_max",
+    "description",
+]
+
+
+def _serialize_value(col: str, value: Any) -> Any:
+    if col in JSON_SERIALIZE_COLUMNS and value is not None:
+        return json.dumps(value)
+    if col == "response" and isinstance(value, list | dict):
+        return json.dumps(value)
+    return value
+
+
+def _serialize_for_excel(col: str, value: Any) -> Any:
+    if value is None:
+        return ""
+    return _serialize_value(col, value)
+
+
+class ResultsFrame:
+    """Polars DataFrame wrapper for orchestrator execution results.
+
+    Converts the raw list[dict] results produced during execution into a
+    normalized DataFrame and provides methods for summarization, scoring
+    pivots, and output to Excel or Parquet.
+    """
+
+    def __init__(self, results: list[dict[str, Any]] | None = None) -> None:
+        self._df = self._normalize(results or [])
+
+    @staticmethod
+    def _normalize(results: list[dict[str, Any]]) -> pl.DataFrame:
+        if not results:
+            return pl.DataFrame(schema=dict.fromkeys(RESULTS_COLUMNS, pl.Utf8))
+
+        rows: list[dict[str, Any]] = []
+        for r in results:
+            row = {col: _serialize_value(col, r.get(col)) for col in RESULTS_COLUMNS}
+            rows.append(row)
+
+        try:
+            return pl.DataFrame(rows)
+        except pl.ComputeError:
+            logger.debug("Polars schema inference failed, falling back to full scan")
+            return pl.DataFrame(rows, infer_schema_length=None)
+
+    @property
+    def df(self) -> pl.DataFrame:
+        return self._df
+
+    @property
+    def is_empty(self) -> bool:
+        return self._df.is_empty()
+
+    def filter(self, *predicates: pl.Expr) -> ResultsFrame:
+        return ResultsFrame.from_df(self._df.filter(*predicates))
+
+    def select(self, *exprs: pl.Expr | str) -> ResultsFrame:
+        return ResultsFrame.from_df(self._df.select(*exprs))
+
+    def sort(self, by: str | list[str], *, descending: bool | list[bool] = False) -> ResultsFrame:
+        return ResultsFrame.from_df(self._df.sort(by, descending=descending))
+
+    @classmethod
+    def from_df(cls, df: pl.DataFrame) -> ResultsFrame:
+        frame = cls.__new__(cls)
+        frame._df = df
+        return frame
+
+    def concat(self, other: ResultsFrame) -> ResultsFrame:
+        return ResultsFrame.from_df(pl.concat([self._df, other._df], how="diagonal"))
+
+    def by_batch(self) -> dict[int, ResultsFrame]:
+        if "batch_id" not in self._df.columns:
+            return {}
+        groups: dict[int, ResultsFrame] = {}
+        for bid, sub_df in self._df.partition_by("batch_id", as_dict=True).items():
+            groups[bid] = ResultsFrame.from_df(sub_df)
+        return groups
+
+    def by_type(self, result_type: str) -> ResultsFrame:
+        return self.filter(pl.col("result_type") == result_type)
+
+    @property
+    def scores_df(self) -> pl.DataFrame:
+        batch_level = self._df.filter(
+            pl.col("batch_name").is_not_null() & pl.col("scores").is_not_null()
+        ).unique(subset=["batch_name"])
+        return batch_level.select(
+            "batch_name", "scores", "composite_score", "scoring_status", "strategy"
+        )
+
+    def summary(
+        self,
+        *,
+        is_batch_mode: bool = False,
+        evaluation_strategy: str = "",
+        has_scoring: bool = False,
+        has_synthesis: bool = False,
+    ) -> dict[str, Any]:
+        if self._df.is_empty():
+            return {"status": "not_run"}
+
+        df = self._df
+        total = len(df)
+
+        status_counts = df.group_by("status").len().rows()
+        status_map = dict(status_counts)
+
+        summary: dict[str, Any] = {
+            "total_prompts": total,
+            "successful": status_map.get("success", 0),
+            "failed": status_map.get("failed", 0),
+            "skipped": status_map.get("skipped", 0),
+            "total_attempts": df.select(pl.col("attempts").sum()).item() or 0,
+        }
+
+        total_tokens = df.select(pl.col("total_tokens").sum()).item() or 0
+        total_cost = df.select(pl.col("cost_usd").sum()).item() or 0.0
+
+        if total_tokens > 0 or total_cost > 0:
+            total_input = df.select(pl.col("input_tokens").sum()).item() or 0
+            total_output = df.select(pl.col("output_tokens").sum()).item() or 0
+            summary["tokens"] = {
+                "input": total_input,
+                "output": total_output,
+                "total": total_tokens,
+            }
+            summary["cost_usd"] = round(total_cost, 6)
+
+        condition_count = df.filter(pl.col("condition").is_not_null()).height
+        if condition_count > 0:
+            summary["prompts_with_conditions"] = condition_count
+
+        if is_batch_mode and "batch_id" in df.columns:
+            batch_ids = df.select(pl.col("batch_id").n_unique()).item() or 0
+            summary["total_batches"] = batch_ids
+            summary["batch_mode"] = True
+
+            failures = df.filter(pl.col("status") == "failed").group_by("batch_id").len()
+            if not failures.is_empty():
+                batch_failures: dict[int, int] = {}
+                for row in failures.iter_rows():
+                    batch_failures[row[0]] = row[1]
+                summary["batches_with_failures"] = batch_failures
+
+        if has_scoring:
+            scoring_col = "scoring_status"
+            if scoring_col in df.columns:
+                scored = df.filter(pl.col(scoring_col).is_not_null() & (pl.col(scoring_col) != ""))
+                if not scored.is_empty():
+                    scoring_counts = scored.group_by(scoring_col).len().rows()
+                    sc_map = dict(scoring_counts)
+
+                    scoring_block: dict[str, Any] = {
+                        "total_scored": scored.height,
+                        "ok": sc_map.get("ok", 0),
+                        "partial": sc_map.get("partial", 0),
+                        "failed": sc_map.get("failed", 0),
+                        "skipped": sc_map.get("skipped", 0),
+                    }
+
+                    if evaluation_strategy:
+                        scoring_block["strategy"] = evaluation_strategy
+
+                    composites = (
+                        scored.filter(pl.col("composite_score").is_not_null())
+                        .select("composite_score")
+                        .to_series()
+                        .to_list()
+                    )
+
+                    if composites:
+                        scoring_block["avg_composite"] = round(sum(composites) / len(composites), 2)
+                        scoring_block["max_composite"] = max(composites)
+                        scoring_block["min_composite"] = min(composites)
+
+                    summary["scoring"] = scoring_block
+
+        if has_synthesis:
+            synth = df.filter(pl.col("result_type") == "synthesis")
+            if not synth.is_empty():
+                synth_counts = synth.group_by("status").len().rows()
+                synth_map = dict(synth_counts)
+                summary["synthesis"] = {
+                    "count": synth.height,
+                    "successful": synth_map.get("success", 0),
+                    "failed": synth_map.get("failed", 0),
+                }
+
+        return summary
+
+    def scores_pivot(self, criteria: list[dict[str, Any]]) -> pl.DataFrame:
+        pivot_criteria = [c for c in criteria if c.get("score_type") == "normalized_score"]
+        if not pivot_criteria:
+            return pl.DataFrame()
+
+        criteria_map = {c["criteria_name"]: c for c in pivot_criteria}
+        criteria_names = list(criteria_map.keys())
+
+        scored = self._df.filter(
+            pl.col("batch_name").is_not_null() & pl.col("scores").is_not_null()
+        ).unique(subset=["batch_name"])
+
+        if scored.is_empty():
+            return pl.DataFrame()
+
+        rows: list[dict[str, Any]] = []
+        composites: dict[str, float | None] = {}
+
+        for row_data in scored.iter_rows(named=True):
+            batch_name = row_data["batch_name"]
+            scores_raw = row_data.get("scores")
+            if not isinstance(scores_raw, str):
+                continue
+            try:
+                scores_dict = json.loads(scores_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(scores_dict, dict):
+                continue
+
+            composites[batch_name] = row_data.get("composite_score")
+
+            for cname in criteria_names:
+                if cname not in scores_dict:
+                    continue
+                value = scores_dict.get(cname)
+                crit = criteria_map[cname]
+                weight = crit.get("weight", 1.0)
+                numeric = value if isinstance(value, int | float) else None
+                rows.append(
+                    {
+                        "batch_name": batch_name,
+                        "criteria_name": cname,
+                        "normalized_score": numeric,
+                        "weight": weight,
+                        "weighted_score": numeric * weight if numeric is not None else None,
+                        "scale_min": crit.get("scale_min", 1),
+                        "scale_max": crit.get("scale_max", 10),
+                        "description": crit.get("description", ""),
+                    }
+                )
+
+        if not rows:
+            return pl.DataFrame()
+
+        pivot_df = pl.DataFrame(rows)
+
+        pivot_df = pivot_df.with_columns(
+            pl.col("normalized_score")
+            .rank(method="dense", descending=True)
+            .over("criteria_name")
+            .alias("rank")
+        )
+
+        pivot_df = pivot_df.with_columns(
+            pl.when(pl.col("normalized_score").is_not_null() & pl.col("rank").is_not_null())
+            .then(
+                pl.when(pl.col("normalized_score").count().over("criteria_name") == 1)
+                .then(pl.lit(100))
+                .otherwise(
+                    (
+                        (pl.col("normalized_score").count().over("criteria_name") - pl.col("rank"))
+                        / pl.max_horizontal(
+                            pl.col("normalized_score").count().over("criteria_name") - 1,
+                            pl.lit(1),
+                        )
+                        * 100
+                    ).cast(pl.Int64)
+                )
+            )
+            .otherwise(pl.lit(0))
+            .alias("percentile")
+        )
+
+        scored_composites = {
+            name: score for name, score in composites.items() if isinstance(score, int | float)
+        }
+        if scored_composites:
+            total = len(scored_composites)
+            sorted_scores = sorted(set(scored_composites.values()), reverse=True)
+            score_to_rank = {s: i + 1 for i, s in enumerate(sorted_scores)}
+
+            composite_rows: list[dict[str, Any]] = []
+            for name, score in scored_composites.items():
+                rank = score_to_rank[score]
+                pct = 100 if total == 1 else round((total - rank) / (total - 1) * 100)
+                composite_rows.append(
+                    {
+                        "batch_name": name,
+                        "criteria_name": "_composite",
+                        "normalized_score": None,
+                        "weight": None,
+                        "weighted_score": score,
+                        "rank": rank,
+                        "percentile": pct,
+                        "scale_min": None,
+                        "scale_max": None,
+                        "description": "Weighted composite score (sum of weighted scores / sum of weights)",
+                    }
+                )
+
+            if composite_rows:
+                composite_df = pl.DataFrame(composite_rows, schema=pivot_df.schema)
+                pivot_df = pl.concat([pivot_df, composite_df], how="diagonal")
+
+        result = pivot_df.select(PIVOT_COLUMNS).with_columns(
+            pl.when(pl.col("criteria_name") == "_composite")
+            .then(pl.lit(1))
+            .otherwise(pl.lit(0))
+            .alias("_sort_key")
+        )
+        return result.sort(["_sort_key", "batch_name"]).drop("_sort_key")
+
+    def to_parquet(self, path: str | Path, metadata: dict[str, str] | None = None) -> str:
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if metadata:
+            import pyarrow.parquet as pq
+
+            table = self._df.to_arrow()
+            existing_meta = dict(table.schema.metadata or {})
+            for k, v in metadata.items():
+                key = k if isinstance(k, bytes) else k.encode("utf-8")
+                val = v if isinstance(v, bytes) else v.encode("utf-8")
+                existing_meta[key] = val
+            table = table.replace_schema_metadata(existing_meta)
+            pq.write_table(table, output_path)
+        else:
+            self._df.write_parquet(output_path)
+
+        logger.info(f"Results written to parquet: {output_path}")
+        return str(output_path)
+
+    @classmethod
+    def from_parquet(cls, path: str | Path) -> ResultsFrame:
+        """Load a ResultsFrame from a parquet file.
+
+        Args:
+            path: Path to the parquet file.
+
+        Returns:
+            ResultsFrame wrapping the loaded DataFrame.
+
+        """
+        df = pl.read_parquet(path)
+        return cls.from_df(df)

--- a/src/orchestrator/state/prompt_node.py
+++ b/src/orchestrator/state/prompt_node.py
@@ -7,7 +7,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+
+from ..models import PromptSpec
 
 
 @dataclass
@@ -23,7 +24,7 @@ class PromptNode:
     """
 
     sequence: int
-    prompt: dict[str, Any]
+    prompt: PromptSpec
     dependencies: set[int] = field(default_factory=set)
     level: int = 0
 

--- a/src/orchestrator/synthesis_runner.py
+++ b/src/orchestrator/synthesis_runner.py
@@ -238,7 +238,7 @@ class SynthesisRunner:
             bid = entry.get("batch_id", 0)
             entry["_all_results"] = entry_results_map.get(bid, {})
 
-        orchestrator.shared_prompt_attr_history = []
+        orchestrator._response_context.clear()
         synthesis_results: list[dict[str, Any]] = []
         results_by_name: dict[str, dict[str, Any]] = {}
 
@@ -275,7 +275,7 @@ class SynthesisRunner:
                     dep_response = dep_result.get("response", "") if dep_result else ""
                     resolved_history += f"--- {dep_name} ---\n{dep_response}\n\n"
                     if dep_result:
-                        orchestrator.shared_prompt_attr_history.append(dep_result)
+                        orchestrator._response_context.record_raw(dep_result)
 
                 prompt_parts = [context]
                 if resolved_history.strip():
@@ -285,24 +285,23 @@ class SynthesisRunner:
 
                 ffai = orchestrator._get_isolated_ffai(synth_prompt.get("client"))
                 call_start = time.monotonic()
-                response = ffai.generate_response(
+                synth_result = ffai.generate_response(
                     prompt=full_prompt,
                     prompt_name=synth_prompt.get("prompt_name"),
                 )
                 call_duration_ms = (time.monotonic() - call_start) * 1000
 
-                usage = getattr(ffai, "last_usage", None)
-                input_tokens = usage.input_tokens if usage else 0
-                output_tokens = usage.output_tokens if usage else 0
-                total_tokens = usage.total_tokens if usage else 0
-                cost_usd = getattr(ffai, "last_cost_usd", 0.0)
+                input_tokens = synth_result.usage.input_tokens if synth_result.usage else 0
+                output_tokens = synth_result.usage.output_tokens if synth_result.usage else 0
+                total_tokens = synth_result.usage.total_tokens if synth_result.usage else 0
+                cost_usd = synth_result.cost_usd
 
                 result = _build_synthesis_result(
                     synth_prompt,
                     status="success",
                     evaluation_strategy=orchestrator.evaluation_strategy,
                     has_scoring=orchestrator.has_scoring,
-                    response=response,
+                    response=synth_result.response,
                     resolved_prompt=full_prompt,
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,

--- a/src/orchestrator/synthesis_runner.py
+++ b/src/orchestrator/synthesis_runner.py
@@ -16,6 +16,8 @@ import time
 from typing import Any
 
 from ..config import get_config
+from .results import ResultBuilder, ResultsFrame
+from .results.frame import _deserialize_json_columns
 from .scoring import ScoreAggregator
 from .synthesis import SynthesisExecutor, build_entry_results_map
 
@@ -36,63 +38,31 @@ def _build_synthesis_result(
     cost_usd: float = 0.0,
     duration_ms: float = 0.0,
 ) -> dict[str, Any]:
-    """Build a synthesis result dictionary.
+    """Build a synthesis result dictionary via ResultBuilder."""
+    builder = ResultBuilder(synth_prompt).as_synthesis()
 
-    Consolidates the duplicated result dict construction from success and
-    failure paths into a single helper.
+    if status == "success":
+        builder.with_response(response)
+        builder.with_resolved_prompt(resolved_prompt)
+        builder.with_attempts(1)
+    else:
+        builder.with_error(error or "unknown error", attempts=1)
+        builder.with_response("")
+        builder.with_resolved_prompt("")
 
-    Args:
-        synth_prompt: Source synthesis prompt dictionary.
-        status: "success" or "failed".
-        evaluation_strategy: Active evaluation strategy name.
-        has_scoring: Whether scoring is enabled.
-        response: LLM response text (empty for failure).
-        resolved_prompt: Full resolved prompt text (empty for failure).
-        error: Error message (None for success).
+    if input_tokens or output_tokens or total_tokens:
+        builder.with_usage(input_tokens, output_tokens, total_tokens)
+    if cost_usd:
+        builder.with_cost(cost_usd)
+    if duration_ms:
+        builder.with_duration(duration_ms)
 
-    Returns:
-        Result dictionary with all synthesis fields.
+    if has_scoring and evaluation_strategy:
+        builder.with_scoring(
+            scores=None, composite_score=None, scoring_status="", strategy=evaluation_strategy
+        )
 
-    """
-    return {
-        "sequence": synth_prompt["sequence"],
-        "prompt_name": synth_prompt.get("prompt_name"),
-        "prompt": synth_prompt["prompt"],
-        "resolved_prompt": resolved_prompt,
-        "response": response,
-        "status": status,
-        "attempts": 1,
-        "batch_id": -1,
-        "batch_name": "",
-        "history": synth_prompt.get("history"),
-        "condition": synth_prompt.get("condition"),
-        "condition_result": None,
-        "condition_error": None,
-        "error": error,
-        "references": None,
-        "result_type": "synthesis",
-        "scores": None,
-        "composite_score": None,
-        "scoring_status": "",
-        "strategy": evaluation_strategy if has_scoring else None,
-        "client": synth_prompt.get("client"),
-        "agent_mode": False,
-        "tool_calls": None,
-        "total_rounds": None,
-        "total_llm_calls": None,
-        "validation_passed": None,
-        "validation_attempts": None,
-        "validation_critique": None,
-        "semantic_query": None,
-        "semantic_filter": None,
-        "query_expansion": None,
-        "rerank": None,
-        "input_tokens": input_tokens,
-        "output_tokens": output_tokens,
-        "total_tokens": total_tokens,
-        "cost_usd": cost_usd,
-        "duration_ms": duration_ms,
-    }
+    return builder.build_dict()
 
 
 class SynthesisRunner:
@@ -210,15 +180,12 @@ class SynthesisRunner:
 
         executor = SynthesisExecutor(max_context_chars=max_context)
 
-        grouped: dict[int, list[dict[str, Any]]] = {}
-        for r in orchestrator.results:
-            batch_id = r.get("batch_id", 0)
-            if batch_id not in grouped:
-                grouped[batch_id] = []
-            grouped[batch_id].append(r)
-
-        sorted_batch_ids = sorted(grouped.keys())
-        batch_results_list = [grouped[bid] for bid in sorted_batch_ids]
+        frame = ResultsFrame(orchestrator.results)
+        batch_groups = frame.by_batch()
+        sorted_batch_ids = sorted(batch_groups.keys())
+        batch_results_list = [
+            _deserialize_json_columns(batch_groups[bid].df.to_dicts()) for bid in sorted_batch_ids
+        ]
 
         entry_results_map = build_entry_results_map(batch_results_list)
 

--- a/src/orchestrator/templating.py
+++ b/src/orchestrator/templating.py
@@ -14,6 +14,7 @@ import logging
 import re
 from typing import Any
 
+from .models import PromptSpec
 from .workbook_parser import parse_history_string
 
 logger = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ def resolve_variables(text: str | None, data_row: dict[str, Any]) -> str | None:
     return re.sub(pattern, replacer, text)
 
 
-def resolve_prompt_variables(prompt: dict[str, Any], data_row: dict[str, Any]) -> dict[str, Any]:
+def resolve_prompt_variables(prompt: PromptSpec, data_row: dict[str, Any]) -> PromptSpec:
     """Resolve all {{variable}} placeholders in a prompt.
 
     Also merges per-row ``_documents`` from the data row into the prompt's

--- a/src/orchestrator/validation.py
+++ b/src/orchestrator/validation.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from .condition_evaluator import ConditionEvaluator
+from .models import ConfigSpec, PromptSpec
 
 logger = logging.getLogger(__name__)
 
@@ -123,8 +124,8 @@ class OrchestratorValidator:
 
     def __init__(
         self,
-        prompts: list[dict[str, Any]],
-        config: dict[str, Any],
+        prompts: list[PromptSpec],
+        config: ConfigSpec,
         *,
         manifest_meta: dict[str, Any] | None = None,
         client_names: list[str] | None = None,
@@ -138,7 +139,7 @@ class OrchestratorValidator:
         synthesis_prompts: list[dict[str, Any]] | None = None,
         skip_scoring_source_check: bool = False,
         skip_synthesis_source_check: bool = False,
-        planning_prompts: list[dict[str, Any]] | None = None,
+        planning_prompts: list[PromptSpec] | None = None,
     ) -> None:
         self.prompts = prompts
         self.config = config

--- a/src/orchestrator/workbook_parser.py
+++ b/src/orchestrator/workbook_parser.py
@@ -20,39 +20,15 @@ from typing import Any
 from openpyxl import Workbook, load_workbook
 
 from ..config import get_config
+from .models import ConfigSpec, DocumentSpec, PromptSpec
+from .results.frame import (
+    PIVOT_COLUMNS,
+    RESULTS_COLUMNS,
+    _serialize_for_excel,
+)
 from .workbook_formatter import WorkbookFormatter
 
 logger = logging.getLogger(__name__)
-
-JSON_SERIALIZE_COLUMNS = frozenset(
-    {"history", "references", "tool_calls", "scores", "extraction_trace"}
-)
-
-
-def _serialize_result_value(header: str, value: Any) -> Any:
-    """JSON-serialize complex result values for output.
-
-    Converts list/dict values in JSON_SERIALIZE_COLUMNS and response
-    to JSON strings. All other values pass through unchanged, including None.
-    """
-    if header in JSON_SERIALIZE_COLUMNS:
-        if value is not None:
-            return json.dumps(value)
-        return value
-    if header == "response" and isinstance(value, list | dict):
-        return json.dumps(value)
-    return value
-
-
-def _prepare_result_value(header: str, value: Any) -> Any:
-    """Convert a raw result value for Excel output.
-
-    Like _serialize_result_value but also converts None to empty string
-    for Excel cells where null is not desired.
-    """
-    if value is None:
-        return ""
-    return _serialize_result_value(header, value)
 
 
 def parse_history_string(history_str: Any) -> list[str] | None:
@@ -231,43 +207,7 @@ class WorkbookParser:
     RESULTS_HEADERS = [
         "batch_id",
         "batch_name",
-        "sequence",
-        "prompt_name",
-        "prompt",
-        "resolved_prompt",
-        "history",
-        "client",
-        "condition",
-        "condition_result",
-        "condition_error",
-        "condition_trace",
-        "response",
-        "status",
-        "attempts",
-        "error",
-        "references",
-        "semantic_query",
-        "semantic_filter",
-        "query_expansion",
-        "rerank",
-        "agent_mode",
-        "tool_calls",
-        "total_rounds",
-        "total_llm_calls",
-        "validation_passed",
-        "validation_attempts",
-        "validation_critique",
-        "scores",
-        "composite_score",
-        "scoring_status",
-        "extraction_trace",
-        "strategy",
-        "result_type",
-        "input_tokens",
-        "output_tokens",
-        "total_tokens",
-        "cost_usd",
-        "duration_ms",
+        *[c for c in RESULTS_COLUMNS if c not in ("batch_id", "batch_name")],
     ]
     TOOLS_HEADERS = [
         "name",
@@ -484,7 +424,7 @@ class WorkbookParser:
         logger.info(f"Workbook validated: {self.workbook_path}")
         return True
 
-    def load_config(self) -> dict[str, Any]:
+    def load_config(self) -> ConfigSpec:
         """Load configuration from config sheet.
 
         Handles both 2-column format (field, value) and 3-column format
@@ -518,7 +458,7 @@ class WorkbookParser:
         logger.debug(f"Loaded config: {config}")
         return config
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(self, config: ConfigSpec) -> list[str]:
         """Validate config values and return list of error messages.
 
         Args:
@@ -570,7 +510,7 @@ class WorkbookParser:
 
         return errors
 
-    def load_prompts(self) -> list[dict[str, Any]]:
+    def load_prompts(self) -> list[PromptSpec]:
         """Load prompts from prompts sheet."""
         wb = load_workbook(self.workbook_path)
         ws = wb[self.PROMPTS_SHEET]
@@ -742,7 +682,7 @@ class WorkbookParser:
         logger.info(f"Loaded {len(clients)} client configurations")
         return clients
 
-    def load_documents(self) -> list[dict[str, Any]]:
+    def load_documents(self) -> list[DocumentSpec]:
         """Load document definitions from documents sheet.
 
         Returns:
@@ -1044,7 +984,7 @@ class WorkbookParser:
                 ws.cell(
                     row=row_idx,
                     column=col_idx,
-                    value=_prepare_result_value(header, result.get(header)),
+                    value=_serialize_for_excel(header, result.get(header)),
                 )
 
         self.formatter.apply_formatting(ws, "results")
@@ -1080,7 +1020,7 @@ class WorkbookParser:
                 ws.cell(
                     row=row_idx,
                     column=col_idx,
-                    value=_prepare_result_value(header, result.get(header)),
+                    value=_serialize_for_excel(header, result.get(header)),
                 )
 
         self.formatter.apply_formatting(ws, "results")
@@ -1089,91 +1029,7 @@ class WorkbookParser:
         logger.info(f"Batch results written to sheet: {sheet_name}")
         return sheet_name
 
-    PIVOT_HEADERS = [
-        "batch_name",
-        "criteria_name",
-        "normalized_score",
-        "weight",
-        "weighted_score",
-        "rank",
-        "percentile",
-        "scale_min",
-        "scale_max",
-        "description",
-    ]
-
-    @staticmethod
-    def _compute_per_criteria_ranks(
-        rows: list[dict[str, Any]],
-    ) -> dict[tuple[str, str], tuple[int, int]]:
-        """Compute per-criteria dense rank and percentile for each row.
-
-        Rows are grouped by criteria_name. Within each group, candidates are
-        ranked by normalized_score. The key is (batch_name, criteria_name)
-        and the value is (rank, percentile).
-
-        Rows with non-numeric normalized_score are excluded from ranking.
-
-        Args:
-            rows: List of row dicts with batch_name, criteria_name, normalized_score.
-
-        Returns:
-            Mapping of (batch_name, criteria_name) to (rank, percentile).
-
-        """
-        groups: dict[str, list[tuple[str, float]]] = {}
-        for row in rows:
-            score = row.get("normalized_score")
-            if not isinstance(score, int | float):
-                continue
-            cname = row["criteria_name"]
-            groups.setdefault(cname, []).append((row["batch_name"], score))
-
-        result: dict[tuple[str, str], tuple[int, int]] = {}
-        for cname, entries in groups.items():
-            total = len(entries)
-            if total == 0:
-                continue
-            sorted_scores = sorted({s for _, s in entries}, reverse=True)
-            score_to_rank = {s: i + 1 for i, s in enumerate(sorted_scores)}
-            for batch_name, score in entries:
-                rank = score_to_rank[score]
-                percentile = 100 if total == 1 else round((total - rank) / (total - 1) * 100)
-                result[(batch_name, cname)] = (rank, percentile)
-
-        return result
-
-    @staticmethod
-    def _compute_composite_ranks(
-        composites: dict[str, float | None],
-    ) -> dict[str, tuple[int, int]]:
-        """Compute dense rank and percentile from composite scores.
-
-        Args:
-            composites: Mapping of batch_name to composite_score (may be None).
-
-        Returns:
-            Mapping of batch_name to (rank, percentile).
-
-        """
-        scored = {
-            name: score for name, score in composites.items() if isinstance(score, int | float)
-        }
-        total = len(scored)
-
-        if total == 0:
-            return {}
-
-        sorted_scores = sorted(set(scored.values()), reverse=True)
-        score_to_rank = {score: i + 1 for i, score in enumerate(sorted_scores)}
-
-        result: dict[str, tuple[int, int]] = {}
-        for name, score in scored.items():
-            rank = score_to_rank[score]
-            percentile = 100 if total == 1 else round((total - rank) / (total - 1) * 100)
-            result[name] = (rank, percentile)
-
-        return result
+    PIVOT_HEADERS = PIVOT_COLUMNS
 
     def write_scores_pivot(
         self,
@@ -1181,13 +1037,11 @@ class WorkbookParser:
         scoring_criteria: list[dict[str, Any]],
         sheet_name: str = "scores_pivot",
     ) -> str | None:
-        """Write a flattened pivot sheet for heatmap-eligible scores.
+        """Write a scores pivot sheet using ResultsFrame for computation.
 
         Only criteria with score_type='normalized_score' are included.
-        Each row contains one (batch_name, criteria_name) pair with the
-        extracted numeric score, weight, weighted score, scale bounds, and
-        human description. A ``_composite`` summary row is appended per
-        batch_name carrying the weighted composite score.
+        Delegates pivot computation to ResultsFrame.scores_pivot() and
+        writes the resulting DataFrame to an Excel worksheet.
 
         Args:
             results: List of result dictionaries (must include batch_name, scores).
@@ -1198,75 +1052,13 @@ class WorkbookParser:
             Name of the pivot sheet created, or None if no pivot-eligible criteria exist.
 
         """
-        pivot_criteria = [c for c in scoring_criteria if c.get("score_type") == "normalized_score"]
-        if not pivot_criteria:
+        from .results import ResultsFrame
+
+        frame = ResultsFrame(results)
+        pivot_df = frame.scores_pivot(scoring_criteria)
+
+        if pivot_df.is_empty():
             return None
-
-        criteria_map = {c["criteria_name"]: c for c in pivot_criteria}
-
-        rows: list[dict[str, Any]] = []
-        seen = set()
-        composites: dict[str, float | None] = {}
-
-        for r in results:
-            batch_name = r.get("batch_name")
-            scores = r.get("scores")
-            if not batch_name or not isinstance(scores, dict):
-                continue
-
-            for criteria_name, value in scores.items():
-                if criteria_name not in criteria_map:
-                    continue
-                key = (batch_name, criteria_name)
-                if key in seen:
-                    continue
-                seen.add(key)
-                composites.setdefault(batch_name, r.get("composite_score"))
-                crit = criteria_map[criteria_name]
-                weight = crit.get("weight", 1.0)
-                rows.append(
-                    {
-                        "batch_name": batch_name,
-                        "criteria_name": criteria_name,
-                        "normalized_score": value if isinstance(value, int | float) else "",
-                        "weight": weight,
-                        "weighted_score": (value * weight)
-                        if isinstance(value, int | float)
-                        else "",
-                        "scale_min": crit.get("scale_min", 1),
-                        "scale_max": crit.get("scale_max", 10),
-                        "description": crit.get("description", ""),
-                    }
-                )
-
-        if not rows:
-            return None
-
-        criteria_ranks = self._compute_per_criteria_ranks(rows)
-        composite_ranks = self._compute_composite_ranks(composites)
-
-        for row in rows:
-            key = (row["batch_name"], row["criteria_name"])
-            rank, percentile = criteria_ranks.get(key, (0, 0))
-            row["rank"] = rank
-            row["percentile"] = percentile
-
-        for batch_name, composite in composites.items():
-            rank, percentile = composite_ranks.get(batch_name, (0, 0))
-            rows.append(
-                {
-                    "batch_name": batch_name,
-                    "criteria_name": "_composite",
-                    "normalized_score": "",
-                    "weight": "",
-                    "weighted_score": composite if isinstance(composite, int | float) else "",
-                    "rank": rank,
-                    "percentile": percentile,
-                    "scale_min": "",
-                    "scale_max": "",
-                    "description": "Weighted composite score (sum of weighted scores / sum of weights)",
-                }
-            )
 
         wb = load_workbook(self.workbook_path)
 
@@ -1279,12 +1071,15 @@ class WorkbookParser:
         for col_idx, header in enumerate(self.PIVOT_HEADERS, start=1):
             ws.cell(row=1, column=col_idx, value=header)
 
-        for row_idx, row_data in enumerate(rows, start=2):
+        for row_idx, row_data in enumerate(pivot_df.iter_rows(named=True), start=2):
             for col_idx, header in enumerate(self.PIVOT_HEADERS, start=1):
-                ws.cell(row=row_idx, column=col_idx, value=row_data.get(header, ""))
+                val = row_data.get(header)
+                if val is None:
+                    val = ""
+                ws.cell(row=row_idx, column=col_idx, value=val)
 
         self.formatter.apply_formatting(ws, "scoring")
 
         wb.save(self.workbook_path)
-        logger.info(f"Scores pivot written to sheet: {sheet_name} ({len(rows)} rows)")
+        logger.info(f"Scores pivot written to sheet: {sheet_name}")
         return sheet_name

--- a/tasks.py
+++ b/tasks.py
@@ -668,10 +668,13 @@ def wb_conditional(
 
 
 @task
-def wb_documents(c: Context, client: str | None = None, explain: bool = False):
+def wb_documents(
+    c: Context, concurrency: str = "3", client: str | None = None, explain: bool = False
+):
     """Create, run, and validate documents workbook.
 
     Args:
+        concurrency: Parallel execution concurrency
         client: Client type from clients.yaml (e.g., 'anthropic', 'gemini')
         explain: Show execution plan instead of running (no API calls)
 
@@ -685,10 +688,13 @@ def wb_documents(c: Context, client: str | None = None, explain: bool = False):
     if explain:
         _run_cmd(
             c,
-            f"python scripts/run_orchestrator.py {config.sample.workbooks.documents} --explain",
+            f"python scripts/run_orchestrator.py {config.sample.workbooks.documents} --explain -c {concurrency}",
         )
         return
-    _run_cmd(c, f"python scripts/run_orchestrator.py {config.sample.workbooks.documents}")
+    _run_cmd(
+        c,
+        f"python scripts/run_orchestrator.py {config.sample.workbooks.documents} -c {concurrency}",
+    )
     _run_cmd(c, f"python {_get_validate_script('documents')} {config.sample.workbooks.documents}")
     print("Documents workbook complete!")
 
@@ -752,10 +758,11 @@ def wb_max(c: Context, concurrency: str = "3", client: str | None = None, explai
 
 
 @task
-def wb_agent(c: Context, client: str | None = None, explain: bool = False):
+def wb_agent(c: Context, concurrency: str = "1", client: str | None = None, explain: bool = False):
     """Create, run, and validate agent workbook.
 
     Args:
+        concurrency: Parallel execution concurrency
         client: Client type from clients.yaml (e.g., 'anthropic', 'gemini')
         explain: Show execution plan instead of running (no API calls)
 
@@ -769,19 +776,25 @@ def wb_agent(c: Context, client: str | None = None, explain: bool = False):
     if explain:
         _run_cmd(
             c,
-            f"python scripts/run_orchestrator.py {config.sample.workbooks.agent} --explain -c 1",
+            f"python scripts/run_orchestrator.py {config.sample.workbooks.agent} --explain -c {concurrency}",
         )
         return
-    _run_cmd(c, f"python scripts/run_orchestrator.py {config.sample.workbooks.agent} -c 1")
+    _run_cmd(
+        c,
+        f"python scripts/run_orchestrator.py {config.sample.workbooks.agent} -c {concurrency}",
+    )
     _run_cmd(c, f"python {_get_validate_script('agent')} {config.sample.workbooks.agent}")
     print("Agent workbook complete!")
 
 
 @task
-def wb_screening(c: Context, client: str | None = None, explain: bool = False):
+def wb_screening(
+    c: Context, concurrency: str = "1", client: str | None = None, explain: bool = False
+):
     """Create, run, and validate screening workbook.
 
     Args:
+        concurrency: Parallel execution concurrency
         client: Client type from clients.yaml (e.g., 'anthropic', 'gemini')
         explain: Show execution plan instead of running (no API calls)
 
@@ -795,12 +808,12 @@ def wb_screening(c: Context, client: str | None = None, explain: bool = False):
     if explain:
         _run_cmd(
             c,
-            f"python scripts/run_orchestrator.py {config.sample.workbooks.screening} --explain -c 1",
+            f"python scripts/run_orchestrator.py {config.sample.workbooks.screening} --explain -c {concurrency}",
         )
         return
     _run_cmd(
         c,
-        f"python scripts/run_orchestrator.py {config.sample.workbooks.screening} -c 1{client_flag}",
+        f"python scripts/run_orchestrator.py {config.sample.workbooks.screening} -c {concurrency}{client_flag}",
     )
     _run_cmd(c, f"python {_get_validate_script('screening')} {config.sample.workbooks.screening}")
     print("Screening workbook complete!")

--- a/tests/test_agent_executor.py
+++ b/tests/test_agent_executor.py
@@ -117,8 +117,7 @@ class TestAgentExecutorExecute:
         )
 
         mock_ffai = MagicMock()
-        mock_ffai._build_prompt.return_value = ("resolved prompt", None)
-        mock_ffai.last_resolved_prompt = "resolved prompt"
+        mock_ffai.build_prompt.return_value = ("resolved prompt", set())
 
         mock_builder = MagicMock()
         mock_builder.build_dict.return_value = {"status": "failed"}
@@ -164,8 +163,7 @@ class TestAgentExecutorExecute:
         )
 
         mock_ffai = MagicMock()
-        mock_ffai._build_prompt.return_value = ("resolved prompt", None)
-        mock_ffai.last_resolved_prompt = "resolved prompt"
+        mock_ffai.build_prompt.return_value = ("resolved prompt", set())
 
         mock_builder = MagicMock()
         mock_builder.build_dict.return_value = {"status": "max_rounds_exceeded"}
@@ -204,8 +202,7 @@ class TestAgentExecutorExecute:
         executor, _ = _make_executor()
 
         mock_ffai = MagicMock()
-        mock_ffai._build_prompt.return_value = ("resolved prompt", None)
-        mock_ffai.last_resolved_prompt = "resolved prompt"
+        mock_ffai.build_prompt.return_value = ("resolved prompt", set())
 
         mock_builder = MagicMock()
         mock_builder.build_dict.return_value = {"status": "failed", "error": "boom"}
@@ -251,8 +248,7 @@ class TestAgentExecutorExecute:
         )
 
         mock_ffai = MagicMock()
-        mock_ffai._build_prompt.return_value = ("resolved prompt", None)
-        mock_ffai.last_resolved_prompt = "resolved prompt"
+        mock_ffai.build_prompt.return_value = ("resolved prompt", set())
 
         mock_builder = MagicMock()
         mock_builder.build_dict.return_value = {"status": "success"}
@@ -297,8 +293,7 @@ class TestAgentExecutorExecute:
         mock_agent_result = AgentResult(response="ok", status="success")
 
         mock_ffai = MagicMock()
-        mock_ffai._build_prompt.return_value = ("resolved", None)
-        mock_ffai.last_resolved_prompt = "resolved"
+        mock_ffai.build_prompt.return_value = ("resolved", set())
 
         mock_builder = MagicMock()
         mock_builder.build_dict.return_value = {"status": "success"}
@@ -389,7 +384,9 @@ class TestAgentExecutorValidateResponse:
 
         def mock_val_generate(*args, **kwargs):
             call_count[0] += 1
-            return "FAIL: Not good enough"
+            from src.core.response_result import ResponseResult
+
+            return ResponseResult(response="FAIL: Not good enough")
 
         mock_ffai_val = MagicMock()
         mock_ffai_val.generate_response = mock_val_generate

--- a/tests/test_ffai.py
+++ b/tests/test_ffai.py
@@ -60,9 +60,9 @@ class TestFFAIGenerateResponse:
         from src.FFAI import FFAI
 
         ffai = FFAI(mock_ffmistralsmall)
-        response = ffai.generate_response("Hello!")
+        result = ffai.generate_response("Hello!")
 
-        assert response == "This is a test response."
+        assert result.response == "This is a test response."
         assert len(ffai.history) == 1
 
     def test_generate_response_with_prompt_name(self, mock_ffmistralsmall):
@@ -352,9 +352,9 @@ class TestFFAICleanResponse:
         mock_ffmistralsmall.generate_response = lambda prompt, **kwargs: "Normal response text"
 
         ffai = FFAI(mock_ffmistralsmall)
-        response = ffai.generate_response("Hello!")
+        result = ffai.generate_response("Hello!")
 
-        assert response == "Normal response text"
+        assert result.response == "Normal response text"
 
 
 class TestFFAISystemInstructions:
@@ -689,9 +689,9 @@ class TestFFAIBuildPrompt:
         from src.FFAI import FFAI
 
         ffai = FFAI(mock_ffmistralsmall)
-        ffai.prompt_attr_history = [
-            {"prompt_name": "prev", "prompt": "Previous Q", "response": "Previous A"}
-        ]
+        ffai._context.prompt_attr_history.extend(
+            [{"prompt_name": "prev", "prompt": "Previous Q", "response": "Previous A"}]
+        )
 
         result, interpolated = ffai._build_prompt("New question", history=["prev"])
 
@@ -706,7 +706,6 @@ class TestFFAIBuildPrompt:
         from src.FFAI import FFAI
 
         ffai = FFAI(mock_ffmistralsmall)
-        ffai.prompt_attr_history = []
 
         result, interpolated = ffai._build_prompt("New question", history=["missing"])
 
@@ -718,10 +717,12 @@ class TestFFAIBuildPrompt:
         from src.FFAI import FFAI
 
         ffai = FFAI(mock_ffmistralsmall)
-        ffai.prompt_attr_history = [
-            {"prompt_name": "q1", "prompt": "Q1", "response": "A1"},
-            {"prompt_name": "q2", "prompt": "Q2", "response": "A2"},
-        ]
+        ffai._context.prompt_attr_history.extend(
+            [
+                {"prompt_name": "q1", "prompt": "Q1", "response": "A1"},
+                {"prompt_name": "q2", "prompt": "Q2", "response": "A2"},
+            ]
+        )
 
         result, interpolated = ffai._build_prompt("New", history=["q1", "q2"])
 
@@ -736,10 +737,12 @@ class TestFFAIBuildPrompt:
         from src.FFAI import FFAI
 
         ffai = FFAI(mock_ffmistralsmall)
-        ffai.prompt_attr_history = [
-            {"prompt_name": "q1", "prompt": "Q1 old", "response": "A1 old"},
-            {"prompt_name": "q1", "prompt": "Q1 new", "response": "A1 new"},
-        ]
+        ffai._context.prompt_attr_history.extend(
+            [
+                {"prompt_name": "q1", "prompt": "Q1 old", "response": "A1 old"},
+                {"prompt_name": "q1", "prompt": "Q1 new", "response": "A1 new"},
+            ]
+        )
 
         result, interpolated = ffai._build_prompt("New", history=["q1"])
 

--- a/tests/test_litellm_orchestrator_integration.py
+++ b/tests/test_litellm_orchestrator_integration.py
@@ -120,7 +120,7 @@ class TestFFAIWithLiteLLM:
 
         response = ffai.generate_response("Hello", prompt_name="greeting")
 
-        assert response == "Test response"
+        assert response.response == "Test response"
         assert len(ffai.history) == 1
         assert ffai.history[0]["prompt_name"] == "greeting"
 
@@ -151,7 +151,7 @@ class TestFFAIWithLiteLLM:
             history=["math"],
         )
 
-        assert "math" in response.lower()
+        assert "math" in response.response.lower()
         assert call_count[0] == 2
 
 

--- a/tests/test_orchestrator_base.py
+++ b/tests/test_orchestrator_base.py
@@ -482,6 +482,12 @@ def _make_base(mock_ffmistralsmall):
     orch.ffai = None
     orch.shared_prompt_attr_history = []
     orch.history_lock = threading.Lock()
+    from src.core.response_context import ResponseContext
+
+    orch._response_context = ResponseContext(
+        shared_prompt_attr_history=orch.shared_prompt_attr_history,
+        history_lock=orch.history_lock,
+    )
     orch.batch_data = []
     orch.is_batch_mode = False
     orch.client_registry = None

--- a/tests/test_results_frame.py
+++ b/tests/test_results_frame.py
@@ -1,0 +1,644 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+import json
+import os
+import sys
+from typing import Any
+
+import polars as pl
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _make_result(
+    *,
+    sequence: int = 1,
+    prompt_name: str = "p1",
+    status: str = "success",
+    attempts: int = 1,
+    batch_id: int | None = None,
+    batch_name: str | None = None,
+    scores: dict[str, Any] | None = None,
+    composite_score: float | None = None,
+    scoring_status: str | None = None,
+    strategy: str | None = None,
+    result_type: str | None = None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    total_tokens: int = 0,
+    cost_usd: float = 0.0,
+    duration_ms: float = 0.0,
+    condition: str | None = None,
+    client: str | None = None,
+    response: str = "ok",
+) -> dict[str, Any]:
+    return {
+        "sequence": sequence,
+        "prompt_name": prompt_name,
+        "prompt": f"prompt for {prompt_name}",
+        "resolved_prompt": None,
+        "history": None,
+        "client": client,
+        "condition": condition,
+        "condition_result": None,
+        "condition_error": None,
+        "condition_trace": None,
+        "response": response,
+        "status": status,
+        "attempts": attempts,
+        "error": None,
+        "references": None,
+        "semantic_query": None,
+        "semantic_filter": None,
+        "query_expansion": None,
+        "rerank": None,
+        "batch_id": batch_id,
+        "batch_name": batch_name,
+        "agent_mode": False,
+        "tool_calls": None,
+        "total_rounds": None,
+        "total_llm_calls": None,
+        "validation_passed": None,
+        "validation_attempts": None,
+        "validation_critique": None,
+        "scores": scores,
+        "composite_score": composite_score,
+        "scoring_status": scoring_status,
+        "extraction_trace": None,
+        "strategy": strategy,
+        "result_type": result_type,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "cost_usd": cost_usd,
+        "duration_ms": duration_ms,
+    }
+
+
+class TestResultsFrameInit:
+    """Tests for ResultsFrame initialization and normalization."""
+
+    def test_empty_results(self):
+        from src.orchestrator.results import ResultsFrame
+
+        frame = ResultsFrame([])
+        assert frame.is_empty
+        assert frame.df.height == 0
+
+    def test_none_results(self):
+        from src.orchestrator.results import ResultsFrame
+
+        frame = ResultsFrame(None)
+        assert frame.is_empty
+
+    def test_single_result(self):
+        from src.orchestrator.results import ResultsFrame
+
+        r = _make_result()
+        frame = ResultsFrame([r])
+        assert not frame.is_empty
+        assert frame.df.height == 1
+        assert frame.df.item(0, "status") == "success"
+
+    def test_json_columns_serialized(self):
+        from src.orchestrator.results import ResultsFrame
+
+        r = _make_result(scores={"skills": 8.0})
+        r["history"] = ["h1", "h2"]
+        frame = ResultsFrame([r])
+        scores_val = frame.df.item(0, "scores")
+        assert isinstance(scores_val, str)
+        assert json.loads(scores_val) == {"skills": 8.0}
+        history_val = frame.df.item(0, "history")
+        assert isinstance(history_val, str)
+
+    def test_results_columns_match_prompt_result(self):
+        from dataclasses import fields
+
+        from src.orchestrator.results import PromptResult
+        from src.orchestrator.results.frame import RESULTS_COLUMNS
+
+        expected = [f.name for f in fields(PromptResult)]
+        assert RESULTS_COLUMNS == expected
+
+    def test_dataframe_has_all_columns(self):
+        from src.orchestrator.results import ResultsFrame
+
+        frame = ResultsFrame([_make_result()])
+        for col in [
+            "sequence",
+            "prompt_name",
+            "status",
+            "batch_id",
+            "scores",
+            "response",
+        ]:
+            assert col in frame.df.columns
+
+
+class TestResultsFrameSummary:
+    """Tests for ResultsFrame.summary()."""
+
+    def test_summary_empty(self):
+        from src.orchestrator.results import ResultsFrame
+
+        frame = ResultsFrame([])
+        assert frame.summary() == {"status": "not_run"}
+
+    def test_summary_basic_counts(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(status="success"),
+            _make_result(status="success"),
+            _make_result(status="failed", sequence=3),
+        ]
+        frame = ResultsFrame(results)
+        s = frame.summary()
+        assert s["total_prompts"] == 3
+        assert s["successful"] == 2
+        assert s["failed"] == 1
+        assert s["skipped"] == 0
+        assert s["total_attempts"] == 3
+
+    def test_summary_with_tokens_and_cost(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(input_tokens=100, output_tokens=50, total_tokens=150, cost_usd=0.001),
+            _make_result(
+                sequence=2, input_tokens=200, output_tokens=100, total_tokens=300, cost_usd=0.002
+            ),
+        ]
+        frame = ResultsFrame(results)
+        s = frame.summary()
+        assert s["tokens"]["input"] == 300
+        assert s["tokens"]["output"] == 150
+        assert s["tokens"]["total"] == 450
+        assert s["cost_usd"] == 0.003
+
+    def test_summary_batch_mode(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(batch_id=1, batch_name="alice"),
+            _make_result(batch_id=2, batch_name="bob", sequence=2),
+        ]
+        frame = ResultsFrame(results)
+        s = frame.summary(is_batch_mode=True)
+        assert s["batch_mode"] is True
+        assert s["total_batches"] == 2
+
+    def test_summary_batch_mode_false_no_batch_fields(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(batch_id=1, batch_name="alice"),
+            _make_result(batch_id=2, batch_name="bob", sequence=2),
+        ]
+        frame = ResultsFrame(results)
+        s = frame.summary(is_batch_mode=False)
+        assert "batch_mode" not in s
+        assert "total_batches" not in s
+
+    def test_summary_with_conditions(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [_make_result(condition="status == 'success'"), _make_result(sequence=2)]
+        frame = ResultsFrame(results)
+        s = frame.summary()
+        assert s["prompts_with_conditions"] == 1
+
+    def test_summary_scoring(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1,
+                batch_name="alice",
+                scores={"skills": 8.0},
+                composite_score=8.0,
+                scoring_status="ok",
+            ),
+            _make_result(
+                batch_id=2,
+                batch_name="bob",
+                sequence=2,
+                scores={"skills": 5.0},
+                composite_score=5.0,
+                scoring_status="ok",
+            ),
+        ]
+        frame = ResultsFrame(results)
+        s = frame.summary(has_scoring=True)
+        assert s["scoring"]["total_scored"] == 2
+        assert s["scoring"]["ok"] == 2
+        assert s["scoring"]["avg_composite"] == 6.5
+        assert s["scoring"]["max_composite"] == 8.0
+        assert s["scoring"]["min_composite"] == 5.0
+
+    def test_summary_synthesis(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(result_type="synthesis", status="success"),
+            _make_result(result_type="synthesis", status="failed", sequence=2),
+        ]
+        frame = ResultsFrame(results)
+        s = frame.summary(has_synthesis=True)
+        assert s["synthesis"]["count"] == 2
+        assert s["synthesis"]["successful"] == 1
+        assert s["synthesis"]["failed"] == 1
+
+    def test_summary_batch_failures(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(batch_id=1, batch_name="alice", status="success"),
+            _make_result(batch_id=1, batch_name="alice", sequence=2, status="failed"),
+            _make_result(batch_id=2, batch_name="bob", sequence=3, status="failed"),
+        ]
+        frame = ResultsFrame(results)
+        s = frame.summary(is_batch_mode=True)
+        assert "batches_with_failures" in s
+
+
+class TestResultsFrameScoresPivot:
+    """Tests for ResultsFrame.scores_pivot()."""
+
+    def _criteria(self, names_with_types: list[tuple[str, str]] | None = None) -> list[dict]:
+        if names_with_types is None:
+            names_with_types = [
+                ("skills_match", "normalized_score"),
+                ("education", "normalized_score"),
+            ]
+        return [
+            {
+                "criteria_name": name,
+                "description": f"{name} desc",
+                "scale_min": 1,
+                "scale_max": 10,
+                "weight": 1.0,
+                "source_prompt": "eval",
+                "score_type": stype,
+            }
+            for name, stype in names_with_types
+        ]
+
+    def test_pivot_basic(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1,
+                batch_name="alice",
+                scores={"skills_match": 8.0, "education": 7.0},
+                composite_score=7.5,
+            ),
+            _make_result(
+                batch_id=2,
+                batch_name="bob",
+                sequence=2,
+                scores={"skills_match": 5.0, "education": 6.0},
+                composite_score=5.5,
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+        assert pivot.height == 6  # 2 batches x 2 criteria + 2 composites
+        assert "batch_name" in pivot.columns
+        assert "rank" in pivot.columns
+        assert "percentile" in pivot.columns
+
+    def test_pivot_returns_empty_for_no_normalized_criteria(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [_make_result(batch_id=1, batch_name="alice", scores={"x": 5.0})]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria([("skills_match", ""), ("education", "")]))
+        assert pivot.height == 0
+
+    def test_pivot_returns_empty_for_no_scores(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [_make_result(batch_id=1, batch_name="alice")]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+        assert pivot.is_empty
+
+    def test_pivot_returns_empty_for_empty_scores_dict(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [_make_result(batch_id=1, batch_name="alice", scores={})]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+        assert pivot.is_empty
+
+    def test_pivot_ranks_correctly(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=8.0
+            ),
+            _make_result(
+                batch_id=2,
+                batch_name="bob",
+                sequence=2,
+                scores={"skills": 5.0},
+                composite_score=5.0,
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria([("skills", "normalized_score")]))
+        criteria_rows = pivot.filter(pl.col("criteria_name") == "skills").sort("batch_name")
+        alice_rank = criteria_rows.filter(pl.col("batch_name") == "alice")["rank"].item()
+        bob_rank = criteria_rows.filter(pl.col("batch_name") == "bob")["rank"].item()
+        assert alice_rank == 1
+        assert bob_rank == 2
+
+    def test_pivot_composite_rows(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=8.0
+            ),
+            _make_result(
+                batch_id=2,
+                batch_name="bob",
+                sequence=2,
+                scores={"skills": 5.0},
+                composite_score=5.0,
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria([("skills", "normalized_score")]))
+        composites = pivot.filter(pl.col("criteria_name") == "_composite")
+        assert composites.height == 2
+
+    def test_pivot_single_batch_no_divide_by_zero(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=8.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria([("skills", "normalized_score")]))
+        assert pivot.height > 0
+        criteria_row = pivot.filter(pl.col("criteria_name") == "skills")
+        assert criteria_row["percentile"].item() == 100
+
+    def test_pivot_excludes_non_matching_criteria(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1,
+                batch_name="alice",
+                scores={"skills_match": 8.0, "raw_years": 12.0},
+                composite_score=8.0,
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(
+            self._criteria([("skills_match", "normalized_score"), ("raw_years", "")])
+        )
+        assert pivot.height == 2  # 1 criteria + 1 composite
+        names = pivot["criteria_name"].to_list()
+        assert "skills_match" in names
+        assert "raw_years" not in names
+
+
+class TestResultsFrameByBatch:
+    """Tests for ResultsFrame.by_batch()."""
+
+    def test_by_batch_groups_correctly(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(batch_id=1, batch_name="alice"),
+            _make_result(batch_id=1, batch_name="alice", sequence=2),
+            _make_result(batch_id=2, batch_name="bob", sequence=3),
+        ]
+        frame = ResultsFrame(results)
+        groups = frame.by_batch()
+        assert len(groups) == 2
+        heights = {g.df.height for g in groups.values()}
+        assert heights == {1, 2}
+
+    def test_by_batch_empty(self):
+        from src.orchestrator.results import ResultsFrame
+
+        frame = ResultsFrame([])
+        assert frame.by_batch() == {}
+
+
+class TestResultsFrameByType:
+    """Tests for ResultsFrame.by_type()."""
+
+    def test_by_type_filters(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(result_type="batch"),
+            _make_result(result_type="synthesis", sequence=2),
+            _make_result(result_type="batch", sequence=3),
+        ]
+        frame = ResultsFrame(results)
+        batch = frame.by_type("batch")
+        assert batch.df.height == 2
+        synth = frame.by_type("synthesis")
+        assert synth.df.height == 1
+
+
+class TestResultsFrameConcat:
+    """Tests for ResultsFrame.concat()."""
+
+    def test_concat_stacks_frames(self):
+        from src.orchestrator.results import ResultsFrame
+
+        f1 = ResultsFrame([_make_result(prompt_name="p1")])
+        f2 = ResultsFrame([_make_result(prompt_name="p2")])
+        combined = f1.concat(f2)
+        assert combined.df.height == 2
+
+    def test_concat_preserves_data(self):
+        from src.orchestrator.results import ResultsFrame
+
+        f1 = ResultsFrame([_make_result(prompt_name="p1", status="success")])
+        f2 = ResultsFrame([_make_result(prompt_name="p2", status="failed")])
+        combined = f1.concat(f2)
+        names = combined.df["prompt_name"].sort().to_list()
+        assert names == ["p1", "p2"]
+
+
+class TestResultsFrameFilterSelectSort:
+    """Tests for ResultsFrame filter/select/sort operations."""
+
+    def test_filter(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(status="success"),
+            _make_result(status="failed", sequence=2),
+        ]
+        frame = ResultsFrame(results)
+        failed = frame.filter(pl.col("status") == "failed")
+        assert failed.df.height == 1
+
+    def test_select(self):
+        from src.orchestrator.results import ResultsFrame
+
+        frame = ResultsFrame([_make_result()])
+        selected = frame.select("prompt_name", "status")
+        assert selected.df.columns == ["prompt_name", "status"]
+
+    def test_sort(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [_make_result(sequence=3), _make_result(sequence=1), _make_result(sequence=2)]
+        frame = ResultsFrame(results)
+        sorted_frame = frame.sort("sequence")
+        assert sorted_frame.df["sequence"].to_list() == [1, 2, 3]
+
+
+class TestResultsFrameScoresDf:
+    """Tests for ResultsFrame.scores_df property."""
+
+    def test_scores_df_deduplicates(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1,
+                batch_name="alice",
+                scores={"skills": 8.0},
+                composite_score=8.0,
+                scoring_status="ok",
+            ),
+            _make_result(
+                batch_id=1,
+                batch_name="alice",
+                sequence=2,
+                scores={"skills": 8.0},
+                composite_score=8.0,
+                scoring_status="ok",
+            ),
+            _make_result(
+                batch_id=2,
+                batch_name="bob",
+                sequence=3,
+                scores={"skills": 5.0},
+                composite_score=5.0,
+                scoring_status="ok",
+            ),
+        ]
+        frame = ResultsFrame(results)
+        sdf = frame.scores_df
+        assert sdf.height == 2
+        assert set(sdf["batch_name"].to_list()) == {"alice", "bob"}
+
+
+class TestResultsFrameParquet:
+    """Tests for ResultsFrame parquet I/O."""
+
+    def test_to_parquet_and_from_parquet(self, tmp_path):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(prompt_name="p1", status="success"),
+            _make_result(prompt_name="p2", status="failed", sequence=2),
+        ]
+        frame = ResultsFrame(results)
+        path = frame.to_parquet(tmp_path / "test.parquet")
+
+        loaded = ResultsFrame.from_parquet(path)
+        assert loaded.df.height == 2
+        assert set(loaded.df["prompt_name"].to_list()) == {"p1", "p2"}
+
+    def test_to_parquet_with_metadata(self, tmp_path):
+        import pyarrow.parquet as pq
+
+        from src.orchestrator.results import ResultsFrame
+
+        results = [_make_result()]
+        frame = ResultsFrame(results)
+        path = frame.to_parquet(
+            tmp_path / "test_meta.parquet",
+            metadata={"run_id": "abc123", "source": "test"},
+        )
+
+        meta = pq.read_schema(path).metadata
+        assert meta[b"run_id"] == b"abc123"
+        assert meta[b"source"] == b"test"
+
+    def test_from_parquet_preserves_data(self, tmp_path):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                prompt_name="eval",
+                status="success",
+                input_tokens=100,
+                output_tokens=50,
+                total_tokens=150,
+                cost_usd=0.001,
+            ),
+        ]
+        frame = ResultsFrame(results)
+        path = frame.to_parquet(tmp_path / "roundtrip.parquet")
+
+        loaded = ResultsFrame.from_parquet(path)
+        assert loaded.df.item(0, "prompt_name") == "eval"
+        assert loaded.df.item(0, "input_tokens") == 100
+
+
+class TestSerializeValue:
+    """Tests for _serialize_value and _serialize_for_excel."""
+
+    def test_serialize_value_none_passthrough(self):
+        from src.orchestrator.results.frame import _serialize_value
+
+        assert _serialize_value("status", None) is None
+        assert _serialize_value("scores", None) is None
+
+    def test_serialize_value_json_columns(self):
+        from src.orchestrator.results.frame import _serialize_value
+
+        result = _serialize_value("scores", {"skills": 8.0})
+        assert isinstance(result, str)
+        assert json.loads(result) == {"skills": 8.0}
+
+    def test_serialize_value_history(self):
+        from src.orchestrator.results.frame import _serialize_value
+
+        result = _serialize_value("history", ["h1", "h2"])
+        assert isinstance(result, str)
+
+    def test_serialize_value_response_dict(self):
+        from src.orchestrator.results.frame import _serialize_value
+
+        result = _serialize_value("response", {"key": "val"})
+        assert isinstance(result, str)
+
+    def test_serialize_for_excel_converts_none(self):
+        from src.orchestrator.results.frame import _serialize_for_excel
+
+        assert _serialize_for_excel("status", None) == ""
+
+    def test_serialize_for_excel_keeps_strings(self):
+        from src.orchestrator.results.frame import _serialize_for_excel
+
+        assert _serialize_for_excel("status", "success") == "success"
+
+    def test_serialize_for_excel_json_columns(self):
+        from src.orchestrator.results.frame import _serialize_for_excel
+
+        result = _serialize_for_excel("scores", {"skills": 8.0})
+        assert isinstance(result, str)
+        assert json.loads(result) == {"skills": 8.0}

--- a/tests/test_workbook_parser.py
+++ b/tests/test_workbook_parser.py
@@ -2,1133 +2,578 @@
 # SPDX-License-Identifier: MIT
 # Contact: antquinonez@farfiner.com
 
-import os
+import json
 
 import pytest
 from openpyxl import load_workbook
 
 
+class TestDeserializeJsonColumns:
+    """Tests for _deserialize_json_columns helper."""
+
+    def test_deserializes_scores_string_to_dict(self):
+        from src.orchestrator.results.frame import _deserialize_json_columns
+
+        rows = [{"scores": '{"skills": 8, "education": 7}', "batch_name": "alice"}]
+        result = _deserialize_json_columns(rows)
+        assert isinstance(result[0]["scores"], dict)
+        assert result[0]["scores"]["skills"] == 8
+        assert result[0]["scores"]["education"] == 7
+
+    def test_deserializes_history_list(self):
+        from src.orchestrator.results.frame import _deserialize_json_columns
+
+        rows = [{"history": '["a", "b"]', "prompt_name": "test"}]
+        result = _deserialize_json_columns(rows)
+        assert isinstance(result[0]["history"], list)
+        assert result[0]["history"] == ["a", "b"]
+
+    def test_leaves_non_json_strings_unchanged(self):
+        from src.orchestrator.results.frame import _deserialize_json_columns
+
+        rows = [{"response": "plain text", "status": "success"}]
+        result = _deserialize_json_columns(rows)
+        assert result[0]["response"] == "plain text"
+        assert result[0]["status"] == "success"
+
+    def test_leaves_none_unchanged(self):
+        from src.orchestrator.results.frame import _deserialize_json_columns
+
+        rows = [{"scores": None, "batch_name": "alice"}]
+        result = _deserialize_json_columns(rows)
+        assert result[0]["scores"] is None
+
+    def test_leaves_already_native_types_unchanged(self):
+        from src.orchestrator.results.frame import _deserialize_json_columns
+
+        rows = [{"scores": {"skills": 8}, "history": ["a"]}]
+        result = _deserialize_json_columns(rows)
+        assert result[0]["scores"] == {"skills": 8}
+        assert result[0]["history"] == ["a"]
+
+
 class TestWorkbookParserInit:
     """Tests for WorkbookParser initialization."""
 
-    def test_init(self, temp_workbook):
-        """Test basic initialization."""
+    def test_init_sets_workbook_path(self, temp_workbook):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook)
+        parser = WorkbookParser(temp_workbook)
+        assert parser.workbook_path == temp_workbook
 
-        assert builder.workbook_path == temp_workbook
+    def test_has_data_sheet_false_when_no_file(self, tmp_path):
+        from src.orchestrator.workbook_parser import WorkbookParser
+
+        parser = WorkbookParser(str(tmp_path / "nonexistent.xlsx"))
+        assert parser.has_data_sheet() is False
+
+    def test_has_clients_sheet_false_when_no_file(self, tmp_path):
+        from src.orchestrator.workbook_parser import WorkbookParser
+
+        parser = WorkbookParser(str(tmp_path / "nonexistent.xlsx"))
+        assert parser.has_clients_sheet() is False
 
 
-class TestWorkbookParserCreateTemplate:
+class TestWorkbookParserTemplate:
     """Tests for template workbook creation."""
 
-    def test_create_template_workbook(self, temp_workbook):
-        """Test creating a template workbook."""
+    def test_create_basic_template(self, tmp_path):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook)
-        result = builder.create_template_workbook()
+        path = str(tmp_path / "template.xlsx")
+        parser = WorkbookParser(path)
+        result = parser.create_template_workbook()
+        assert result == path
 
-        assert result == temp_workbook
-        assert os.path.exists(temp_workbook)
-
-    def test_template_has_config_sheet(self, temp_workbook):
-        """Test that template has config sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook()
-
-        wb = load_workbook(temp_workbook)
+        wb = load_workbook(path)
         assert "config" in wb.sheetnames
-
-    def test_template_has_prompts_sheet(self, temp_workbook):
-        """Test that template has prompts sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook()
-
-        wb = load_workbook(temp_workbook)
         assert "prompts" in wb.sheetnames
+        assert "data" not in wb.sheetnames
 
-    def test_template_config_has_required_fields(self, temp_workbook):
-        """Test that config sheet has required fields."""
+    def test_create_template_with_data_sheet(self, tmp_path):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook()
+        path = str(tmp_path / "template_data.xlsx")
+        parser = WorkbookParser(path)
+        parser.create_template_workbook(with_data_sheet=True)
 
-        wb = load_workbook(temp_workbook)
+        wb = load_workbook(path)
+        assert "data" in wb.sheetnames
+
+    def test_create_template_with_all_sheets(self, tmp_path):
+        from src.orchestrator.workbook_parser import WorkbookParser
+
+        path = str(tmp_path / "template_all.xlsx")
+        parser = WorkbookParser(path)
+        parser.create_template_workbook(
+            with_data_sheet=True,
+            with_clients_sheet=True,
+            with_documents_sheet=True,
+            with_tools_sheet=True,
+            with_scoring_sheet=True,
+            with_synthesis_sheet=True,
+        )
+
+        wb = load_workbook(path)
+        for sheet in [
+            "config",
+            "prompts",
+            "data",
+            "clients",
+            "documents",
+            "tools",
+            "scoring",
+            "synthesis",
+        ]:
+            assert sheet in wb.sheetnames
+
+    def test_template_has_created_at(self, tmp_path):
+        from src.orchestrator.workbook_parser import WorkbookParser
+
+        path = str(tmp_path / "template_ts.xlsx")
+        parser = WorkbookParser(path)
+        parser.create_template_workbook()
+
+        wb = load_workbook(path)
         ws = wb["config"]
-
-        fields = {row[0] for row in ws.iter_rows(min_row=2, values_only=True) if row[0]}
-
-        assert "model" in fields
-        assert "api_key_env" in fields
-        assert "max_retries" in fields
-        assert "temperature" in fields
-        assert "max_tokens" in fields
-        assert "system_instructions" in fields
-
-    def test_template_prompts_has_required_headers(self, temp_workbook):
-        """Test that prompts sheet has required headers."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook()
-
-        wb = load_workbook(temp_workbook)
-        ws = wb["prompts"]
-
-        headers = [cell.value for cell in ws[1]]
-
-        assert "sequence" in headers
-        assert "prompt_name" in headers
-        assert "prompt" in headers
-        assert "history" in headers
+        fields = [ws.cell(row=r, column=1).value for r in range(2, ws.max_row + 1)]
+        assert "created_at" in fields
 
 
-class TestWorkbookParserValidate:
+class TestWorkbookParserValidation:
     """Tests for workbook validation."""
 
-    def test_validate_workbook_success(self, temp_workbook_with_data):
-        """Test validating a valid workbook."""
+    def test_validate_valid_workbook(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_data)
-        result = builder.validate_workbook()
+        parser = WorkbookParser(temp_workbook_with_data)
+        assert parser.validate_workbook() is True
 
-        assert result is True
-
-    def test_validate_workbook_not_found(self, temp_workbook):
-        """Test validating non-existent workbook."""
+    def test_validate_missing_workbook(self, tmp_path):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook)
-
+        parser = WorkbookParser(str(tmp_path / "missing.xlsx"))
         with pytest.raises(FileNotFoundError):
-            builder.validate_workbook()
+            parser.validate_workbook()
 
-    def test_validate_workbook_missing_config(self, temp_workbook):
-        """Test validating workbook missing config sheet."""
+    def test_validate_missing_config_sheet(self, tmp_path):
         from openpyxl import Workbook
 
         from src.orchestrator.workbook_parser import WorkbookParser
 
         wb = Workbook()
-        wb.create_sheet("prompts")
-        wb.save(temp_workbook)
+        wb.active.title = "prompts"
+        wb["prompts"]["A1"] = "sequence"
+        wb["prompts"]["B1"] = "prompt_name"
+        wb["prompts"]["C1"] = "prompt"
+        wb["prompts"]["D1"] = "history"
+        path = str(tmp_path / "no_config.xlsx")
+        wb.save(path)
 
-        builder = WorkbookParser(temp_workbook)
+        parser = WorkbookParser(path)
+        with pytest.raises(ValueError, match="Missing required sheet"):
+            parser.validate_workbook()
 
-        with pytest.raises(ValueError, match="Missing required sheet: config"):
-            builder.validate_workbook()
-
-    def test_validate_workbook_missing_prompts(self, temp_workbook):
-        """Test validating workbook missing prompts sheet."""
+    def test_validate_missing_required_columns(self, tmp_path):
         from openpyxl import Workbook
 
         from src.orchestrator.workbook_parser import WorkbookParser
 
         wb = Workbook()
-        wb.create_sheet("config")
-        wb.save(temp_workbook)
+        wb.active.title = "config"
+        wb["config"]["A1"] = "field"
+        wb["config"]["B1"] = "value"
+        ws_prompts = wb.create_sheet(title="prompts")
+        ws_prompts["A1"] = "sequence"
+        ws_prompts["B1"] = "prompt_name"
+        path = str(tmp_path / "missing_cols.xlsx")
+        wb.save(path)
 
-        builder = WorkbookParser(temp_workbook)
-
-        with pytest.raises(ValueError, match="Missing required sheet: prompts"):
-            builder.validate_workbook()
-
-    def test_validate_workbook_missing_columns(self, temp_workbook):
-        """Test validating workbook missing required columns."""
-        from openpyxl import Workbook
-
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        wb = Workbook()
-        wb.create_sheet("config")
-        wb.create_sheet("prompts")
-        ws = wb["prompts"]
-        ws["A1"] = "sequence"
-        wb.save(temp_workbook)
-
-        builder = WorkbookParser(temp_workbook)
-
+        parser = WorkbookParser(path)
         with pytest.raises(ValueError, match="Missing required columns"):
-            builder.validate_workbook()
+            parser.validate_workbook()
 
 
 class TestWorkbookParserLoadConfig:
-    """Tests for loading configuration."""
+    """Tests for config loading."""
 
-    def test_load_config(self, temp_workbook_with_data, sample_config):
-        """Test loading configuration from workbook."""
+    def test_load_config_returns_dict(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_data)
-        config = builder.load_config()
+        parser = WorkbookParser(temp_workbook_with_data)
+        config = parser.load_config()
+        assert isinstance(config, dict)
+        assert "model" in config
+        assert config["model"] == "mistral-small-2503"
 
-        assert config["model"] == sample_config["model"]
-        assert config["api_key_env"] == sample_config["api_key_env"]
-        assert config["max_retries"] == sample_config["max_retries"]
-        assert config["temperature"] == sample_config["temperature"]
-
-    def test_load_config_type_conversion(self, temp_workbook):
-        """Test that config values are converted to correct types."""
-        from openpyxl import Workbook
-
+    def test_load_config_type_coercion(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        wb = Workbook()
-        ws = wb.active
-        ws.title = "config"
-        ws["A1"] = "field"
-        ws["B1"] = "value"
-        ws["A2"] = "max_retries"
-        ws["B2"] = "5"
-        ws["A3"] = "temperature"
-        ws["B3"] = "0.5"
-        ws["A4"] = "max_tokens"
-        ws["B4"] = "8192"
-        wb.save(temp_workbook)
-
-        builder = WorkbookParser(temp_workbook)
-        config = builder.load_config()
-
-        assert isinstance(config["max_retries"], int)
-        assert isinstance(config["temperature"], float)
-        assert isinstance(config["max_tokens"], int)
+        parser = WorkbookParser(temp_workbook_with_data)
+        config = parser.load_config()
+        assert isinstance(config.get("max_retries"), int)
+        assert isinstance(config.get("temperature"), float)
 
 
 class TestWorkbookParserLoadPrompts:
-    """Tests for loading prompts."""
+    """Tests for prompt loading."""
 
-    def test_load_prompts(self, temp_workbook_with_data, sample_prompts):
-        """Test loading prompts from workbook."""
+    def test_load_prompts_returns_list(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_data)
-        prompts = builder.load_prompts()
-
+        parser = WorkbookParser(temp_workbook_with_data)
+        prompts = parser.load_prompts()
+        assert isinstance(prompts, list)
         assert len(prompts) == 3
-        assert prompts[0]["prompt_name"] == "greeting"
-        assert prompts[1]["prompt_name"] == "math"
-        assert prompts[2]["prompt_name"] == "followup"
 
     def test_load_prompts_sorted_by_sequence(self, temp_workbook_with_data):
-        """Test that prompts are sorted by sequence number."""
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_data)
-        prompts = builder.load_prompts()
-
+        parser = WorkbookParser(temp_workbook_with_data)
+        prompts = parser.load_prompts()
         sequences = [p["sequence"] for p in prompts]
         assert sequences == sorted(sequences)
 
-    def test_load_prompts_parses_history(self, temp_workbook_with_data):
-        """Test that history column is parsed correctly."""
+    def test_load_prompts_fields(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_data)
-        prompts = builder.load_prompts()
+        parser = WorkbookParser(temp_workbook_with_data)
+        prompts = parser.load_prompts()
+        p = prompts[0]
+        assert p["sequence"] == 1
+        assert p["prompt_name"] == "greeting"
+        assert p["prompt"] == "Hello, how are you?"
 
-        followup = next(p for p in prompts if p["prompt_name"] == "followup")
-        assert followup["history"] == ["math", "greeting"]
 
+class TestWorkbookParserLoadData:
+    """Tests for batch data loading."""
 
-class TestWorkbookParserParseHistoryString:
-    """Tests for parsing history strings."""
-
-    def test_parse_history_string_json_array(self, temp_workbook):
-        """Test parsing JSON array format."""
+    def test_load_data_no_sheet_returns_empty(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook)
+        parser = WorkbookParser(temp_workbook_with_data)
+        assert parser.load_data() == []
 
-        result = builder._parse_history_string('["a", "b", "c"]')
-
-        assert result == ["a", "b", "c"]
-
-    def test_parse_history_string_quoted(self, temp_workbook):
-        """Test parsing quoted format."""
+    def test_load_data_with_batch_sheet(self, temp_workbook_with_batch_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook)
+        parser = WorkbookParser(temp_workbook_with_batch_data)
+        data = parser.load_data()
+        assert len(data) == 3
+        assert data[0]["region"] == "north"
 
-        result = builder._parse_history_string('["math", "greeting"]')
-
-        assert result == ["math", "greeting"]
-
-    def test_parse_history_string_none(self, temp_workbook):
-        """Test parsing None."""
+    def test_get_data_columns(self, temp_workbook_with_batch_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string(None)
-
-        assert result is None
-
-    def test_parse_history_string_empty(self, temp_workbook):
-        """Test parsing empty string."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string("")
-
-        assert result is None
-
-    def test_parse_history_string_already_list(self, temp_workbook):
-        """Test parsing already-list input."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string(["a", "b"])
-
-        assert result == ["a", "b"]
-
-    def test_parse_history_string_comma_separated(self, temp_workbook):
-        """Test parsing comma-separated format."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string("[a, b, c]")
-
-        assert result == ["a", "b", "c"]
-
-
-class TestWorkbookParserSmartQuotes:
-    """Tests for smart quote normalization in history strings."""
-
-    def test_smart_double_quotes(self, temp_workbook):
-        """Test parsing history with smart double quotes."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string('["interesting_story"]')
-
-        assert result == ["interesting_story"]
-
-    def test_smart_single_quotes(self, temp_workbook):
-        """Test parsing history with smart single quotes."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string("['test', 'value']")
-
-        assert result == ["test", "value"]
-
-    def test_mixed_ascii_and_smart_quotes(self, temp_workbook):
-        """Test parsing history with mixed ASCII and smart quotes."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string('["ascii", "smart"]')
-
-        assert result == ["ascii", "smart"]
-
-    def test_backward_compatibility_ascii_quotes(self, temp_workbook):
-        """Test that ASCII quotes still work (backward compatibility)."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string('["item1", "item2"]')
-
-        assert result == ["item1", "item2"]
-
-    def test_sample_workbook_exact_string(self, temp_workbook):
-        """Test the exact string from sample_workbook.xlsx."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string('["interesting_story"]')
-
-        assert result == ["interesting_story"]
-
-    def test_multiple_items_smart_quotes(self, temp_workbook):
-        """Test multiple items with smart quotes."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-
-        result = builder._parse_history_string('["first", "second", "third"]')
-
-        assert result == ["first", "second", "third"]
+        parser = WorkbookParser(temp_workbook_with_batch_data)
+        cols = parser.get_data_columns()
+        assert "id" in cols
+        assert "batch_name" in cols
+        assert "region" in cols
 
 
 class TestWorkbookParserWriteResults:
-    """Tests for writing results."""
+    """Tests for write_results and write_batch_results."""
 
-    def test_write_results(self, temp_workbook_with_data):
-        """Test writing results to workbook."""
+    def test_write_results_creates_sheet(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_data)
-
+        parser = WorkbookParser(temp_workbook_with_data)
         results = [
             {
-                "batch_id": 0,
-                "batch_name": "",
                 "sequence": 1,
                 "prompt_name": "test",
-                "prompt": "Hello?",
+                "prompt": "hello",
+                "response": "world",
+                "status": "success",
+                "attempts": 1,
+                "scores": {"skill": 8.0},
                 "history": None,
-                "response": "Hi!",
-                "status": "success",
-                "attempts": 1,
-                "error": None,
-            }
-        ]
-
-        sheet_name = builder.write_results(results, "results_test")
-
-        assert sheet_name == "results_test"
-
-        wb = load_workbook(temp_workbook_with_data)
-        assert "results_test" in wb.sheetnames
-
-    def test_write_results_creates_new_sheet_name(self, temp_workbook_with_data):
-        """Test that duplicate sheet names get timestamp suffix."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-
-        builder.write_results([], "results_test")
-        sheet_name = builder.write_results([], "results_test")
-
-        assert sheet_name != "results_test"
-
-    def test_write_results_has_all_columns(self, temp_workbook_with_data):
-        """Test that results sheet has all required columns."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-
-        results = [
-            {
                 "batch_id": 0,
                 "batch_name": "",
-                "sequence": 1,
-                "prompt_name": "test",
-                "prompt": "Hello?",
-                "history": ["a"],
-                "response": "Hi!",
-                "status": "success",
-                "attempts": 1,
-                "error": None,
             }
         ]
-
-        builder.write_results(results, "results_test")
-
-        wb = load_workbook(temp_workbook_with_data)
-        ws = wb["results_test"]
-
-        headers = [cell.value for cell in ws[1]]
-
-        assert "batch_id" in headers
-        assert "batch_name" in headers
-        assert "sequence" in headers
-        assert "prompt_name" in headers
-        assert "prompt" in headers
-        assert "history" in headers
-        assert "response" in headers
-        assert "status" in headers
-        assert "attempts" in headers
-        assert "error" in headers
-        assert "validation_passed" in headers
-        assert "validation_attempts" in headers
-        assert "validation_critique" in headers
-
-    def test_write_results_converts_history_to_json(self, temp_workbook_with_data):
-        """Test that history is converted to JSON string."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-
-        results = [
-            {
-                "batch_id": 0,
-                "batch_name": "",
-                "sequence": 1,
-                "prompt_name": "test",
-                "prompt": "Hello?",
-                "history": ["a", "b"],
-                "response": "Hi!",
-                "status": "success",
-                "attempts": 1,
-                "error": None,
-            }
-        ]
-
-        builder.write_results(results, "results_test")
+        sheet_name = parser.write_results(results, "results")
+        assert sheet_name == "results"
 
         wb = load_workbook(temp_workbook_with_data)
-        ws = wb["results_test"]
+        assert "results" in wb.sheetnames
+        ws = wb["results"]
+        assert ws.cell(row=1, column=1).value == "batch_id"
+        assert ws.cell(row=2, column=1).value == 0
 
-        history_cell = ws.cell(row=2, column=7).value
-
-        assert history_cell == '["a", "b"]'
-
-
-class TestWorkbookParserBatchData:
-    """Tests for batch data sheet functionality."""
-
-    def test_has_data_sheet_true(self, temp_workbook_with_batch_data):
-        """Test has_data_sheet returns True when data sheet exists."""
+    def test_write_results_scores_as_json_string(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_batch_data)
-        assert builder.has_data_sheet() is True
-
-    def test_has_data_sheet_false(self, temp_workbook_with_data):
-        """Test has_data_sheet returns False when no data sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-        assert builder.has_data_sheet() is False
-
-    def test_load_data(self, temp_workbook_with_batch_data):
-        """Test loading data from data sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_batch_data)
-        data = builder.load_data()
-
-        assert len(data) == 3
-        assert data[0]["region"] == "north"
-        assert data[1]["region"] == "south"
-        assert data[2]["region"] == "east"
-
-    def test_load_data_columns(self, temp_workbook_with_batch_data):
-        """Test that data columns are loaded correctly."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_batch_data)
-        data = builder.load_data()
-
-        assert "id" in data[0]
-        assert "batch_name" in data[0]
-        assert "region" in data[0]
-        assert "product" in data[0]
-        assert "price" in data[0]
-        assert "quantity" in data[0]
-
-    def test_load_data_empty_when_no_sheet(self, temp_workbook_with_data):
-        """Test load_data returns empty list when no data sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-        data = builder.load_data()
-
-        assert data == []
-
-    def test_get_data_columns(self, temp_workbook_with_batch_data):
-        """Test getting data column names."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_batch_data)
-        columns = builder.get_data_columns()
-
-        assert "id" in columns
-        assert "batch_name" in columns
-        assert "region" in columns
-
-    def test_create_template_with_data_sheet(self, temp_workbook):
-        """Test creating template with data sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook(with_data_sheet=True)
-
-        wb = load_workbook(temp_workbook)
-        assert "data" in wb.sheetnames
-
-    def test_create_template_without_data_sheet(self, temp_workbook):
-        """Test creating template without data sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook(with_data_sheet=False)
-
-        wb = load_workbook(temp_workbook)
-        assert "data" not in wb.sheetnames
-
-
-class TestWorkbookParserWriteBatchResults:
-    """Tests for writing batch results to separate sheets."""
-
-    def test_write_batch_results(self, temp_workbook_with_batch_data):
-        """Test writing batch results to a separate sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_batch_data)
-
+        parser = WorkbookParser(temp_workbook_with_data)
         results = [
             {
                 "sequence": 1,
-                "prompt_name": "intro",
-                "prompt": "Analyze north widget_a.",
+                "prompt_name": "eval",
+                "prompt": "test",
+                "response": "ok",
+                "status": "success",
+                "attempts": 1,
+                "scores": {"skills": 8.0, "education": 7.0},
                 "history": None,
-                "response": "Analysis complete.",
-                "status": "success",
-                "attempts": 1,
-                "error": None,
+                "batch_id": 0,
+                "batch_name": "alice",
             }
         ]
+        parser.write_results(results, "results")
 
-        sheet_name = builder.write_batch_results(results, "north_widget_a")
+        wb = load_workbook(temp_workbook_with_data)
+        ws = wb["results"]
+        scores_col = None
+        for col in range(1, ws.max_column + 1):
+            if ws.cell(row=1, column=col).value == "scores":
+                scores_col = col
+                break
+        assert scores_col is not None
+        cell_val = ws.cell(row=2, column=scores_col).value
+        parsed = json.loads(cell_val)
+        assert parsed == {"skills": 8.0, "education": 7.0}
 
-        assert "north_widget_a" in sheet_name
-
-        wb = load_workbook(temp_workbook_with_batch_data)
-        assert sheet_name in wb.sheetnames
-
-    def test_write_results_with_batch_info(self, temp_workbook_with_batch_data):
-        """Test writing results with batch_id and batch_name columns."""
+    def test_write_batch_results_creates_sheet(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_batch_data)
-
+        parser = WorkbookParser(temp_workbook_with_data)
         results = [
             {
+                "sequence": 1,
+                "prompt_name": "test",
+                "prompt": "hello",
+                "response": "world",
+                "status": "success",
+                "attempts": 1,
+                "history": None,
                 "batch_id": 1,
-                "batch_name": "north_widget_a",
-                "sequence": 1,
-                "prompt_name": "intro",
-                "prompt": "Analyze north widget_a.",
-                "history": None,
-                "response": "Analysis complete.",
-                "status": "success",
-                "attempts": 1,
-                "error": None,
+                "batch_name": "alice",
             }
         ]
+        sheet_name = parser.write_batch_results(results, "alice")
+        assert "alice" in sheet_name
 
-        builder.write_results(results, "results_test")
+    def test_write_results_dedup_sheet_name(self, temp_workbook_with_data):
+        from src.orchestrator.workbook_parser import WorkbookParser
 
-        wb = load_workbook(temp_workbook_with_batch_data)
-        ws = wb["results_test"]
+        parser = WorkbookParser(temp_workbook_with_data)
+        results = [
+            {"sequence": 1, "prompt_name": "t", "prompt": "", "status": "success", "attempts": 1}
+        ]
+        first = parser.write_results(results, "results")
+        second = parser.write_results(results, "results")
+        assert first != second
 
-        headers = [cell.value for cell in ws[1]]
 
-        assert "batch_id" in headers
-        assert "batch_name" in headers
+class TestWorkbookParserHistoryParsing:
+    """Tests for history string parsing."""
+
+    def test_parse_valid_json_list(self):
+        from src.orchestrator.workbook_parser import parse_history_string
+
+        result = parse_history_string('["a", "b", "c"]')
+        assert result == ["a", "b", "c"]
+
+    def test_parse_single_value(self):
+        from src.orchestrator.workbook_parser import parse_history_string
+
+        result = parse_history_string("my_prompt")
+        assert result == ["my_prompt"]
+
+    def test_parse_none_returns_none(self):
+        from src.orchestrator.workbook_parser import parse_history_string
+
+        assert parse_history_string(None) is None
+
+    def test_parse_empty_returns_none(self):
+        from src.orchestrator.workbook_parser import parse_history_string
+
+        assert parse_history_string("") is None
+
+    def test_parse_list_returns_list(self):
+        from src.orchestrator.workbook_parser import parse_history_string
+
+        result = parse_history_string(["a", "b"])
+        assert result == ["a", "b"]
+
+    def test_parse_smart_quotes(self):
+        from src.orchestrator.workbook_parser import parse_history_string
+
+        result = parse_history_string("[\u201ca\u201d, \u201cb\u201d]")
+        assert isinstance(result, list)
+        assert result == ["a", "b"]
+
+    def test_comma_separated_no_brackets_returns_single(self):
+        from src.orchestrator.workbook_parser import parse_history_string
+
+        result = parse_history_string("alpha, beta, gamma")
+        assert result == ["alpha, beta, gamma"]
 
 
 class TestWorkbookParserClientsSheet:
-    """Tests for clients sheet functionality."""
+    """Tests for clients sheet loading."""
 
-    def test_has_clients_sheet_true(self, temp_workbook):
-        """Test has_clients_sheet returns True when clients sheet exists."""
+    def test_load_clients_empty_when_no_sheet(self, temp_workbook_with_data):
+        from src.orchestrator.workbook_parser import WorkbookParser
+
+        parser = WorkbookParser(temp_workbook_with_data)
+        assert parser.load_clients() == []
+
+    def test_load_clients_from_workbook(self, tmp_path):
         from openpyxl import Workbook
 
         from src.orchestrator.workbook_parser import WorkbookParser
 
         wb = Workbook()
-        wb.create_sheet("config")
-        wb.create_sheet("prompts")
-        wb.create_sheet("clients")
-        wb.save(temp_workbook)
+        wb.active.title = "config"
+        wb["config"]["A1"] = "field"
+        wb["config"]["B1"] = "value"
 
-        builder = WorkbookParser(temp_workbook)
-        assert builder.has_clients_sheet() is True
+        ws_prompts = wb.create_sheet(title="prompts")
+        ws_prompts["A1"] = "sequence"
+        ws_prompts["B1"] = "prompt_name"
+        ws_prompts["C1"] = "prompt"
+        ws_prompts["D1"] = "history"
 
-    def test_has_clients_sheet_false(self, temp_workbook_with_data):
-        """Test has_clients_sheet returns False when no clients sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-        assert builder.has_clients_sheet() is False
-
-    def test_load_clients(self, temp_workbook):
-        """Test loading clients from clients sheet."""
-        from openpyxl import Workbook
-
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        wb = Workbook()
-        wb.create_sheet("config")
-        wb.create_sheet("prompts")
-
-        ws_clients = wb.create_sheet("clients")
-        headers = ["name", "client_type", "api_key_env", "model", "temperature"]
-        for col, header in enumerate(headers, start=1):
-            ws_clients.cell(row=1, column=col, value=header)
-
+        ws_clients = wb.create_sheet(title="clients")
+        headers = ["name", "client_type", "api_key_env", "model"]
+        for col, h in enumerate(headers, start=1):
+            ws_clients.cell(row=1, column=col, value=h)
         ws_clients.cell(row=2, column=1, value="fast")
         ws_clients.cell(row=2, column=2, value="mistral-small")
         ws_clients.cell(row=2, column=3, value="MISTRALSMALL_KEY")
         ws_clients.cell(row=2, column=4, value="mistral-small-2503")
-        ws_clients.cell(row=2, column=5, value=0.3)
 
-        ws_clients.cell(row=3, column=1, value="smart")
-        ws_clients.cell(row=3, column=2, value="anthropic")
-        ws_clients.cell(row=3, column=3, value="ANTHROPIC_API_KEY")
+        path = str(tmp_path / "clients.xlsx")
+        wb.save(path)
 
-        wb.save(temp_workbook)
-
-        builder = WorkbookParser(temp_workbook)
-        clients = builder.load_clients()
-
-        assert len(clients) == 2
+        parser = WorkbookParser(path)
+        clients = parser.load_clients()
+        assert len(clients) == 1
         assert clients[0]["name"] == "fast"
         assert clients[0]["client_type"] == "mistral-small"
-        assert clients[1]["name"] == "smart"
 
-    def test_load_clients_empty_when_no_sheet(self, temp_workbook_with_data):
-        """Test load_clients returns empty list when no clients sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
 
-        builder = WorkbookParser(temp_workbook_with_data)
-        clients = builder.load_clients()
+class TestSynthesisRunnerScoresDeserialization:
+    """Integration test verifying scores survive the ResultsFrame round-trip."""
 
-        assert clients == []
-
-    def test_create_template_with_clients_sheet(self, temp_workbook):
-        """Test creating template with clients sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook(with_clients_sheet=True)
-
-        wb = load_workbook(temp_workbook)
-        assert "clients" in wb.sheetnames
-
-    def test_load_prompts_with_client_column(self, temp_workbook):
-        """Test loading prompts that include client column."""
-        from openpyxl import Workbook
-
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        wb = Workbook()
-        wb.create_sheet("config")
-
-        ws_prompts = wb.create_sheet("prompts")
-        headers = ["sequence", "prompt_name", "prompt", "history", "client"]
-        for col, header in enumerate(headers, start=1):
-            ws_prompts.cell(row=1, column=col, value=header)
-
-        ws_prompts.cell(row=2, column=1, value=1)
-        ws_prompts.cell(row=2, column=2, value="classify")
-        ws_prompts.cell(row=2, column=3, value="Classify this text")
-        ws_prompts.cell(row=2, column=4, value="")
-        ws_prompts.cell(row=2, column=5, value="fast")
-
-        ws_prompts.cell(row=3, column=1, value=2)
-        ws_prompts.cell(row=3, column=2, value="analyze")
-        ws_prompts.cell(row=3, column=3, value="Analyze deeply")
-        ws_prompts.cell(row=3, column=4, value="")
-        ws_prompts.cell(row=3, column=5, value="smart")
-
-        del wb["Sheet"]
-        wb.save(temp_workbook)
-
-        builder = WorkbookParser(temp_workbook)
-        prompts = builder.load_prompts()
-
-        assert len(prompts) == 2
-        assert prompts[0]["client"] == "fast"
-        assert prompts[1]["client"] == "smart"
-
-
-class TestWorkbookParserAgentHeaders:
-    """Tests for agent-related headers in workbook parser."""
-
-    def test_prompts_headers_includes_agent_mode(self):
-        """PROMPTS_HEADERS should include agent_mode column."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        assert "agent_mode" in WorkbookParser.PROMPTS_HEADERS
-
-    def test_prompts_headers_includes_tools_columns(self):
-        """PROMPTS_HEADERS should include tools and max_tool_rounds."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        assert "tools" in WorkbookParser.PROMPTS_HEADERS
-        assert "max_tool_rounds" in WorkbookParser.PROMPTS_HEADERS
-
-    def test_prompts_headers_include_notes_column(self):
-        """PROMPTS_HEADERS should include notes for user annotations."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        assert "notes" in WorkbookParser.PROMPTS_HEADERS
-
-    def test_results_headers_includes_agent_columns(self):
-        """RESULTS_HEADERS should include agent metadata columns."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        assert "agent_mode" in WorkbookParser.RESULTS_HEADERS
-        assert "tool_calls" in WorkbookParser.RESULTS_HEADERS
-        assert "total_rounds" in WorkbookParser.RESULTS_HEADERS
-        assert "total_llm_calls" in WorkbookParser.RESULTS_HEADERS
-
-    def test_tools_headers_defined(self):
-        """TOOLS_HEADERS should be defined."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        assert hasattr(WorkbookParser, "TOOLS_HEADERS")
-        assert "name" in WorkbookParser.TOOLS_HEADERS
-        assert "description" in WorkbookParser.TOOLS_HEADERS
-        assert "parameters" in WorkbookParser.TOOLS_HEADERS
-        assert "implementation" in WorkbookParser.TOOLS_HEADERS
-        assert "enabled" in WorkbookParser.TOOLS_HEADERS
-
-    def test_template_includes_agent_mode_column(self, temp_workbook):
-        """Template workbook should include agent_mode column in prompts sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook()
-
-        wb = load_workbook(temp_workbook)
-        ws_prompts = wb["prompts"]
-        headers = [ws_prompts.cell(row=1, column=col).value for col in range(1, 20)]
-        assert "agent_mode" in headers
-
-    def test_load_prompts_reads_notes_column(self, temp_workbook):
-        """Prompt notes should round-trip through workbook loading."""
-        from openpyxl import Workbook
-
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        wb = Workbook()
-        ws_config = wb.active
-        ws_config.title = "config"
-        ws_prompts = wb.create_sheet("prompts")
-
-        headers = WorkbookParser.PROMPTS_HEADERS
-        for col, header in enumerate(headers, start=1):
-            ws_prompts.cell(row=1, column=col, value=header)
-
-        values = {
-            "sequence": 1,
-            "prompt_name": "annotated_prompt",
-            "prompt": "Say hello",
-            "history": "",
-            "notes": "This prompt is for smoke testing.",
-        }
-        for col, header in enumerate(headers, start=1):
-            ws_prompts.cell(row=2, column=col, value=values.get(header, ""))
-
-        wb.save(temp_workbook)
-
-        parser = WorkbookParser(temp_workbook)
-        prompts = parser.load_prompts()
-
-        assert prompts[0]["notes"] == "This prompt is for smoke testing."
-
-    def test_create_template_with_tools_sheet(self, temp_workbook):
-        """Template workbook can be created with a tools sheet."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook)
-        builder.create_template_workbook(with_tools_sheet=True)
-
-        wb = load_workbook(temp_workbook)
-        assert "tools" in wb.sheetnames
-
-    def test_load_tools_sheet(self, temp_workbook):
-        """Tools sheet can be loaded from workbook."""
-        from openpyxl import Workbook
-
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        wb = Workbook()
-        wb.create_sheet("config")
-        wb.create_sheet("prompts")
-
-        ws_tools = wb.create_sheet("tools")
-        tool_headers = ["name", "description", "parameters", "implementation", "enabled"]
-        for col, header in enumerate(tool_headers, start=1):
-            ws_tools.cell(row=1, column=col, value=header)
-
-        ws_tools.cell(row=2, column=1, value="calculate")
-        ws_tools.cell(row=2, column=2, value="Evaluate math")
-        ws_tools.cell(row=2, column=3, value='{"type":"object"}')
-        ws_tools.cell(row=2, column=4, value="builtin:calculate")
-        ws_tools.cell(row=2, column=5, value=True)
-
-        del wb["Sheet"]
-        wb.save(temp_workbook)
-
-        builder = WorkbookParser(temp_workbook)
-        tools = builder.load_tools()
-
-        assert len(tools) == 1
-        assert tools[0]["name"] == "calculate"
-        assert tools[0]["implementation"] == "builtin:calculate"
-
-
-class TestPrepareResultValue:
-    """Tests for _prepare_result_value serialization helper."""
-
-    def test_none_returns_empty_string(self):
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        assert _prepare_result_value("status", None) == ""
-
-    def test_string_passes_through(self):
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        assert _prepare_result_value("status", "success") == "success"
-
-    def test_int_passes_through(self):
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        assert _prepare_result_value("sequence", 5) == 5
-
-    def test_bool_false_passes_through(self):
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        assert _prepare_result_value("agent_mode", False) is False
-
-    def test_int_zero_passes_through(self):
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        assert _prepare_result_value("total_rounds", 0) == 0
-
-    def test_history_serialized_to_json(self):
-        import json
-
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        result = _prepare_result_value("history", ["a", "b"])
-        assert json.loads(result) == ["a", "b"]
-
-    def test_references_serialized_to_json(self):
-        import json
-
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        result = _prepare_result_value("references", ["doc1", "doc2"])
-        assert json.loads(result) == ["doc1", "doc2"]
-
-    def test_tool_calls_serialized_to_json(self):
-        import json
-
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        result = _prepare_result_value("tool_calls", [{"tool_name": "calc"}])
-        assert json.loads(result) == [{"tool_name": "calc"}]
-
-    def test_empty_list_history_serialized_to_json(self):
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        assert _prepare_result_value("history", []) == "[]"
-
-    def test_response_string_passes_through(self):
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        assert _prepare_result_value("response", "Hello") == "Hello"
-
-    def test_response_dict_serialized_to_json(self):
-        import json
-
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        result = _prepare_result_value("response", {"key": "value"})
-        assert json.loads(result) == {"key": "value"}
-
-    def test_response_list_serialized_to_json(self):
-        import json
-
-        from src.orchestrator.workbook_parser import _prepare_result_value
-
-        result = _prepare_result_value("response", [1, 2, 3])
-        assert json.loads(result) == [1, 2, 3]
-
-
-class TestWriteResultsRoundTrip:
-    """Tests that verify header-to-data alignment after writing results."""
-
-    def test_header_data_alignment(self, temp_workbook_with_data):
-        """Each header should map to the correct data column."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
+    def test_scores_survive_results_frame_round_trip(self):
+        from src.orchestrator.results import ResultsFrame
+        from src.orchestrator.results.frame import _deserialize_json_columns
 
         results = [
             {
                 "sequence": 1,
-                "prompt_name": "test",
-                "prompt": "Hello?",
-                "resolved_prompt": "Hello? resolved",
-                "history": ["a"],
-                "response": "Hi!",
-                "status": "success",
-                "attempts": 2,
-            }
-        ]
-
-        builder.write_results(results, "results_test")
-
-        wb = load_workbook(temp_workbook_with_data)
-        ws = wb["results_test"]
-
-        for col_idx, header in enumerate(builder.RESULTS_HEADERS, start=1):
-            header_cell = ws.cell(row=1, column=col_idx).value
-            assert header_cell == header, (
-                f"Column {col_idx}: expected '{header}', got '{header_cell}'"
-            )
-
-        assert ws.cell(row=2, column=3).value == 1
-        assert ws.cell(row=2, column=4).value == "test"
-        assert ws.cell(row=2, column=5).value == "Hello?"
-        assert ws.cell(row=2, column=6).value == "Hello? resolved"
-        assert ws.cell(row=2, column=7).value == '["a"]'
-        assert ws.cell(row=2, column=13).value == "Hi!"
-        assert ws.cell(row=2, column=14).value == "success"
-        assert ws.cell(row=2, column=15).value == 2
-
-    def test_falsy_values_written_correctly(self, temp_workbook_with_data):
-        """agent_mode=False, total_rounds=0, total_llm_calls=0 should not become empty string."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-
-        results = [
-            {
-                "sequence": 1,
-                "prompt_name": "test",
-                "prompt": "Hello?",
-                "agent_mode": False,
-                "total_rounds": 0,
-                "total_llm_calls": 0,
+                "prompt_name": "eval",
+                "prompt": "test",
                 "status": "success",
                 "attempts": 1,
-            }
-        ]
-
-        builder.write_results(results, "results_test")
-
-        wb = load_workbook(temp_workbook_with_data)
-        ws = wb["results_test"]
-
-        agent_mode_col = builder.RESULTS_HEADERS.index("agent_mode") + 1
-        total_rounds_col = builder.RESULTS_HEADERS.index("total_rounds") + 1
-        total_llm_calls_col = builder.RESULTS_HEADERS.index("total_llm_calls") + 1
-
-        assert ws.cell(row=2, column=agent_mode_col).value is False
-        assert ws.cell(row=2, column=total_rounds_col).value == 0
-        assert ws.cell(row=2, column=total_llm_calls_col).value == 0
-
-    def test_validation_fields_written_correctly(self, temp_workbook_with_data):
-        """validation_passed, validation_attempts, validation_critique round-trip correctly."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-
-        results = [
+                "batch_id": 0,
+                "batch_name": "alice",
+                "scores": {"skills": 8.0, "education": 7.0},
+                "composite_score": 7.5,
+            },
             {
-                "sequence": 1,
-                "prompt_name": "test",
-                "prompt": "Hello?",
+                "sequence": 2,
+                "prompt_name": "eval",
+                "prompt": "test",
                 "status": "success",
                 "attempts": 1,
-                "validation_passed": False,
-                "validation_attempts": 3,
-                "validation_critique": "Response too short",
-            }
-        ]
-
-        builder.write_results(results, "results_test")
-
-        wb = load_workbook(temp_workbook_with_data)
-        ws = wb["results_test"]
-
-        vp_col = builder.RESULTS_HEADERS.index("validation_passed") + 1
-        va_col = builder.RESULTS_HEADERS.index("validation_attempts") + 1
-        vc_col = builder.RESULTS_HEADERS.index("validation_critique") + 1
-
-        assert ws.cell(row=2, column=vp_col).value is False
-        assert ws.cell(row=2, column=va_col).value == 3
-        assert ws.cell(row=2, column=vc_col).value == "Response too short"
-
-    def test_none_values_written_as_empty_string(self, temp_workbook_with_data):
-        """None values should become empty string in Excel (openpyxl reads back as None)."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-
-        results = [
-            {
-                "sequence": 1,
-                "prompt": "Hello?",
-                "status": "success",
-                "attempts": 1,
-                "error": None,
-                "response": None,
-            }
-        ]
-
-        builder.write_results(results, "results_test")
-
-        wb = load_workbook(temp_workbook_with_data)
-        ws = wb["results_test"]
-
-        error_col = builder.RESULTS_HEADERS.index("error") + 1
-        response_col = builder.RESULTS_HEADERS.index("response") + 1
-
-        assert ws.cell(row=2, column=error_col).value in ("", None)
-        assert ws.cell(row=2, column=response_col).value in ("", None)
-
-    def test_batch_results_same_alignment_as_write_results(self, temp_workbook_with_data):
-        """write_batch_results should produce identical column layout to write_results."""
-        from src.orchestrator.workbook_parser import WorkbookParser
-
-        builder = WorkbookParser(temp_workbook_with_data)
-
-        results = [
-            {
                 "batch_id": 1,
-                "batch_name": "test_batch",
-                "sequence": 1,
-                "prompt_name": "test",
-                "prompt": "Hello?",
-                "response": "Hi!",
-                "status": "success",
-                "attempts": 1,
-            }
+                "batch_name": "bob",
+                "scores": {"skills": 5.0, "education": 6.0},
+                "composite_score": 5.5,
+            },
         ]
 
-        builder.write_results(results, "results_test")
-        builder.write_batch_results(results, "batch1")
+        frame = ResultsFrame(results)
+        batch_groups = frame.by_batch()
+        batch_results_list = [
+            _deserialize_json_columns(batch_groups[bid].df.to_dicts())
+            for bid in sorted(batch_groups.keys())
+        ]
 
-        wb = load_workbook(temp_workbook_with_data)
-        ws_main = wb["results_test"]
+        assert isinstance(batch_results_list[0][0]["scores"], dict)
+        assert batch_results_list[0][0]["scores"]["skills"] == 8.0
+        assert isinstance(batch_results_list[1][0]["scores"], dict)
+        assert batch_results_list[1][0]["scores"]["skills"] == 5.0
 
-        batch_sheet_name = None
-        for name in wb.sheetnames:
-            if name.startswith("results_batch1"):
-                batch_sheet_name = name
-                break
-        assert batch_sheet_name is not None
+    def test_scores_used_for_tiebreaking_after_deserialization(self):
+        from src.orchestrator.results import ResultsFrame
+        from src.orchestrator.results.frame import _deserialize_json_columns
+        from src.orchestrator.synthesis import SynthesisExecutor
 
-        ws_batch = wb[batch_sheet_name]
+        results = [
+            {
+                "sequence": 1,
+                "prompt_name": "eval",
+                "prompt": "test",
+                "status": "success",
+                "attempts": 1,
+                "batch_id": 0,
+                "batch_name": "alice",
+                "scores": {"skills": 8.0, "education": 7.0},
+                "composite_score": 7.5,
+            },
+            {
+                "sequence": 1,
+                "prompt_name": "eval",
+                "prompt": "test",
+                "status": "success",
+                "attempts": 1,
+                "batch_id": 1,
+                "batch_name": "bob",
+                "scores": {"skills": 6.0, "education": 9.0},
+                "composite_score": 7.5,
+            },
+        ]
 
-        for col_idx, header in enumerate(builder.RESULTS_HEADERS, start=1):
-            main_header = ws_main.cell(row=1, column=col_idx).value
-            batch_header = ws_batch.cell(row=1, column=col_idx).value
-            assert main_header == batch_header == header
+        frame = ResultsFrame(results)
+        batch_groups = frame.by_batch()
+        batch_results_list = [
+            _deserialize_json_columns(batch_groups[bid].df.to_dicts())
+            for bid in sorted(batch_groups.keys())
+        ]
 
-        for col_idx in range(1, len(builder.RESULTS_HEADERS) + 1):
-            main_val = ws_main.cell(row=2, column=col_idx).value
-            batch_val = ws_batch.cell(row=2, column=col_idx).value
-            assert main_val == batch_val, (
-                f"Column {col_idx} ({builder.RESULTS_HEADERS[col_idx - 1]}): "
-                f"write_results={main_val!r}, write_batch_results={batch_val!r}"
-            )
+        executor = SynthesisExecutor()
+        criteria = [{"criteria_name": "skills"}, {"criteria_name": "education"}]
+        sorted_entries = executor.sort_entries(
+            batch_results_list, scoring_criteria=criteria, has_scoring=True
+        )
+        assert sorted_entries[0]["batch_name"] == "alice"
+        assert sorted_entries[0]["scores"]["skills"] == 8.0
+
+    def test_scores_appear_in_context_format_after_deserialization(self):
+        from src.orchestrator.results import ResultsFrame
+        from src.orchestrator.results.frame import _deserialize_json_columns
+        from src.orchestrator.synthesis import SynthesisExecutor
+
+        results = [
+            {
+                "sequence": 1,
+                "prompt_name": "eval",
+                "prompt": "test",
+                "status": "success",
+                "attempts": 1,
+                "batch_id": 0,
+                "batch_name": "alice",
+                "scores": {"skills": 8.0},
+                "composite_score": 8.0,
+                "response": "Good candidate",
+            },
+        ]
+
+        frame = ResultsFrame(results)
+        batch_groups = frame.by_batch()
+        batch_results_list = [
+            _deserialize_json_columns(batch_groups[bid].df.to_dicts())
+            for bid in sorted(batch_groups.keys())
+        ]
+
+        executor = SynthesisExecutor(max_context_chars=50000)
+        context = executor.format_entry_context(batch_results_list[0], [], include_scores=True)
+        assert "skills: 8.0/10" in context
 
 
 class TestWorkbookParserWriteScoresPivot:


### PR DESCRIPTION
## Summary

- **Extract `ResultsFrame`** into `src/orchestrator/results/frame.py` to centralize result normalization, parquet serialization, and workbook write-back. Removes duplicated logic from `orchestrator_base`, `excel_orchestrator`, `manifest`, and `workbook_parser`.
- **Fix synthesis score deserialization bug** — scores were JSON strings after `ResultsFrame.to_dicts()` round-trip, causing `sort_entries` tiebreaking and `_format_scores_block` context formatting to silently fail. Adds `_deserialize_json_columns()` helper in `frame.py` and wires it into `synthesis_runner.py`.
- **Remove dead None check** in `workbook_parser.py:write_scores_pivot` — `scores_pivot()` never returns `None`.
- **Restore WorkbookParser test coverage** — 35 new tests covering init, templates, validation, config/loading, prompt loading, data loading, result writing, history parsing, clients sheet, and synthesis runner score round-trip integration.
- **Normalize invoke task `-c` parameter** across `wb_documents`, `wb_agent`, `wb_screening` to match `wb_max`, `wb_conditional`, `wb_batch`, etc.

## Test plan

- [x] All 1,834 unit tests pass (0 failures)
- [x] `ruff check` + `ruff format` clean
- [x] `inv wb.max -c 3` — 135 prompts, 97 succeeded, 38 skipped, 0 failed, 6/6 sections validated
- [x] `inv wb.conditional -c 3` — 50 prompts, 48 succeeded, 2 skipped, 0 failed, 8/8 sections validated
- [x] `inv wb.documents` — 23 prompts, 23 succeeded, 0 failed, 5/5 sections validated
- [x] Manifest observability demo — 8/8 prompts succeeded, condition traces, token/cost tracking verified