### PR TITLE
feat: post-PR#73 improvements — guide rename, percent_rank, synthesis name fix, Polars refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1312,4 +1312,4 @@ AZURE_PHI_KEY=your-key-here
 - This is proprietary code - do not share externally
 - Integration tests require real API keys in `.env`
 - Use `inv --list` to see all available commands
-- Use `inv help` for detailed task documentation
+- Use `inv guide` for a project-level task overview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Guidelines for AI coding agents working in this repository.
 
+## Git Operations
+
+**Never commit, push, or submit a pull request unless the user explicitly asks.**
+This includes `git commit`, `git push`, `gh pr create`, and any other remote-submitted action.
+Wait for the user to request each of these steps individually.
+
 ## Build/Lint/Test Commands
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ inv explain ./analysis.xlsx
 **Output includes:**
 
 1. **Execution DAG** — prompts grouped by dependency level with annotations for history, references, client routing, conditions, and agent mode
-2. **Dependency Edges** — every edge labeled `[history]` or `[condition]`, with a `⚠` warning on implicit edges created by condition variable references (e.g., `{{fetch.status}}` silently creates a dependency on `fetch`)
+2. **Dependency Edges** — shows which prompts must finish before others can start. Each edge is labeled `[history]` (you explicitly declared it via the `history` field) or `[condition]` (the system inferred it because your condition references another prompt's output, e.g., `{{fetch.status}}` means `fetch` must run first). Implicit `⚠` edges are flagged so you can spot undeclared dependencies.
 3. **Cost Estimate** — total LLM calls and estimated input tokens
 
 ```

--- a/src/orchestrator/results/frame.py
+++ b/src/orchestrator/results/frame.py
@@ -359,39 +359,50 @@ class ResultsFrame:
             name: score for name, score in composites.items() if isinstance(score, int | float)
         }
         if scored_composites:
-            total = len(scored_composites)
-            sorted_scores = sorted(set(scored_composites.values()), reverse=True)
-            score_to_rank = {s: i + 1 for i, s in enumerate(sorted_scores)}
-
-            n_below_composite = {
-                name: sum(1 for s in scored_composites.values() if s < score)
-                for name, score in scored_composites.items()
-            }
-
-            composite_rows: list[dict[str, Any]] = []
-            for name, score in scored_composites.items():
-                rank = score_to_rank[score]
-                pct = 100 if total == 1 else round((total - rank) / (total - 1) * 100)
-                pct_rank = 100 if total == 1 else round(n_below_composite[name] / (total - 1) * 100)
-                composite_rows.append(
+            composite_df = (
+                pl.DataFrame(
                     {
-                        "batch_name": name,
-                        "criteria_name": "_composite",
-                        "normalized_score": None,
-                        "weight": None,
-                        "weighted_score": score,
-                        "rank": rank,
-                        "percentile": pct,
-                        "percent_rank": pct_rank,
-                        "scale_min": None,
-                        "scale_max": None,
-                        "description": "Weighted composite score (sum of weighted scores / sum of weights)",
+                        "batch_name": list(scored_composites.keys()),
+                        "weighted_score": list(scored_composites.values()),
                     }
                 )
-
-            if composite_rows:
-                composite_df = pl.DataFrame(composite_rows, schema=pivot_df.schema)
-                pivot_df = pl.concat([pivot_df, composite_df], how="diagonal")
+                .with_columns(
+                    pl.lit("_composite").alias("criteria_name"),
+                    pl.lit(None).cast(pl.Float64).alias("normalized_score"),
+                    pl.lit(None).cast(pl.Float64).alias("weight"),
+                    pl.lit(None).cast(pl.Int64).alias("scale_min"),
+                    pl.lit(None).cast(pl.Int64).alias("scale_max"),
+                    pl.lit(
+                        "Weighted composite score (sum of weighted scores / sum of weights)"
+                    ).alias("description"),
+                )
+                .with_columns(
+                    pl.col("weighted_score").rank(method="dense", descending=True).alias("rank"),
+                )
+                .with_columns(
+                    pl.when(pl.col("weighted_score").count() == 1)
+                    .then(pl.lit(100))
+                    .otherwise(
+                        (
+                            (pl.col("weighted_score").count() - pl.col("rank"))
+                            / pl.max_horizontal(pl.col("weighted_score").count() - 1, pl.lit(1))
+                            * 100
+                        ).cast(pl.Int64)
+                    )
+                    .alias("percentile"),
+                    pl.when(pl.col("weighted_score").count() == 1)
+                    .then(pl.lit(100))
+                    .otherwise(
+                        (
+                            (pl.col("weighted_score").rank(method="min") - 1)
+                            / pl.max_horizontal(pl.col("weighted_score").count() - 1, pl.lit(1))
+                            * 100
+                        ).cast(pl.Int64)
+                    )
+                    .alias("percent_rank"),
+                )
+            )
+            pivot_df = pl.concat([pivot_df, composite_df], how="diagonal")
 
         result = pivot_df.select(PIVOT_COLUMNS).with_columns(
             pl.when(pl.col("criteria_name") == "_composite")

--- a/src/orchestrator/results/frame.py
+++ b/src/orchestrator/results/frame.py
@@ -57,6 +57,7 @@ PIVOT_COLUMNS = [
     "weighted_score",
     "rank",
     "percentile",
+    "percent_rank",
     "scale_min",
     "scale_max",
     "description",
@@ -334,6 +335,26 @@ class ResultsFrame:
             .alias("percentile")
         )
 
+        pivot_df = pivot_df.with_columns(
+            pl.when(pl.col("normalized_score").is_not_null())
+            .then(
+                pl.when(pl.col("normalized_score").count().over("criteria_name") == 1)
+                .then(pl.lit(100))
+                .otherwise(
+                    (
+                        (pl.col("normalized_score").rank(method="min").over("criteria_name") - 1)
+                        / pl.max_horizontal(
+                            pl.col("normalized_score").count().over("criteria_name") - 1,
+                            pl.lit(1),
+                        )
+                        * 100
+                    ).cast(pl.Int64)
+                )
+            )
+            .otherwise(pl.lit(0))
+            .alias("percent_rank")
+        )
+
         scored_composites = {
             name: score for name, score in composites.items() if isinstance(score, int | float)
         }
@@ -342,10 +363,16 @@ class ResultsFrame:
             sorted_scores = sorted(set(scored_composites.values()), reverse=True)
             score_to_rank = {s: i + 1 for i, s in enumerate(sorted_scores)}
 
+            n_below_composite = {
+                name: sum(1 for s in scored_composites.values() if s < score)
+                for name, score in scored_composites.items()
+            }
+
             composite_rows: list[dict[str, Any]] = []
             for name, score in scored_composites.items():
                 rank = score_to_rank[score]
                 pct = 100 if total == 1 else round((total - rank) / (total - 1) * 100)
+                pct_rank = 100 if total == 1 else round(n_below_composite[name] / (total - 1) * 100)
                 composite_rows.append(
                     {
                         "batch_name": name,
@@ -355,6 +382,7 @@ class ResultsFrame:
                         "weighted_score": score,
                         "rank": rank,
                         "percentile": pct,
+                        "percent_rank": pct_rank,
                         "scale_min": None,
                         "scale_max": None,
                         "description": "Weighted composite score (sum of weighted scores / sum of weights)",

--- a/src/orchestrator/synthesis.py
+++ b/src/orchestrator/synthesis.py
@@ -123,6 +123,13 @@ class SynthesisExecutor:
             "result_type",
             "batch_id",
             "_all_results",
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "cost_usd",
+            "duration_ms",
+            "condition_trace",
+            "extraction_trace",
         }
 
         for key, value in entry.items():

--- a/tasks.py
+++ b/tasks.py
@@ -181,8 +181,8 @@ def _validate_single_workbook(name: str) -> tuple[str, bool, str]:
 
 
 @task
-def help(c: Context) -> None:
-    """Show detailed help information."""
+def guide(c: Context) -> None:
+    """Show a project-level guide to available tasks and workflows."""
     print("""
 FFClients Invoke Tasks
 ======================
@@ -192,7 +192,8 @@ A Python-based task runner for managing test workbooks and orchestration.
 USAGE:
     inv <task> [options]
     inv --list              # Show all available tasks
-    inv --help <task>       # Show help for specific task
+    inv --help <task>       # Show args and docstring for a specific task
+    inv guide               # Show this guide
 
 WORKBOOK TASKS (inv wb.<task>):
     inv wb.create           # Create all test workbooks
@@ -203,18 +204,20 @@ WORKBOOK TASKS (inv wb.<task>):
     inv wb.all              # Full pipeline: clean, create, run, validate
 
 INDIVIDUAL WORKBOOKS (create + run + validate):
-    inv wb.basic            # Create, run, and validate basic workbook
-    inv wb.multiclient      # Create, run, and validate multiclient workbook
-    inv wb.conditional      # Create, run, and validate conditional workbook
-    inv wb.documents        # Create, run, and validate documents workbook
-    inv wb.batch            # Create, run, and validate batch workbook
-    inv wb.max              # Create, run, and validate max workbook
-    inv wb.agent            # Create, run, and validate agent workbook
-    inv wb.screening        # Create, run, and validate screening workbook
+    Each supports: -c CONCURRENCY, --client CLIENT, --explain
+    inv wb.basic            # Basic workbook (parallel execution, dependency chains)
+    inv wb.multiclient      # Multi-client workbook (named client configurations)
+    inv wb.conditional      # Conditional workbook (expression-based skip logic)
+    inv wb.documents        # Documents workbook (document injection, RAG search)
+    inv wb.batch            # Batch workbook (variable templating, per-row execution)
+    inv wb.max              # Max workbook (batch + conditional + multi-client)
+    inv wb.agent            # Agent workbook (agentic tool-call loop)
+    inv wb.screening        # Screening workbook (per-row docs, scoring, synthesis)
 
 SCREENING TASKS (inv screening.<task>):
-    inv screening.create    # Create screening workbook from a folder of resumes
+    inv screening.create    # Create screening workbook
     inv screening.run       # Create and run screening workbook
+    inv screening.manifest  # Create manifest (YAML) and run
 
 RAG TASKS (inv rag.<task>):
     inv rag.status          # Show RAG indexing status
@@ -223,38 +226,38 @@ RAG TASKS (inv rag.<task>):
     inv rag.rebuild         # Rebuild indexes from workbook
     inv rag.stats           # Show detailed RAG statistics
 
-MCP TASKS:
-    (removed — MCP server shelved until protocol stabilizes)
-
 OTHER TASKS:
+    inv explain WORKBOOK    # Preview execution plan (no API calls)
     inv lint                # Run linting (ruff)
     inv format              # Run code formatting (ruff format)
     inv test                # Run tests (excludes integration)
     inv test-all            # Run all tests including integration
     inv config-check        # Display current configuration
 
-OPTIONS:
-    -c, --concurrency N     # Set parallel execution concurrency (default: varies by workbook)
-    --parallel              # Enable parallel execution for create/run tasks
-    --client CLIENT        # Client type from clients.yaml (e.g., 'anthropic', 'gemini')
+COMMON OPTIONS:
+    --explain               # Show execution plan instead of running (wb.* only)
+    -c, --concurrency N     # Parallel execution concurrency (default varies by workbook)
+    --client CLIENT         # Client type from clients.yaml (e.g., 'gemini', 'mistral-small')
+    --parallel              # Enable parallel execution for bulk create/run tasks
     -q, --quiet             # Suppress detailed output
 
 EXAMPLES:
-    inv wb.create --parallel                     # Create all workbooks in parallel
-    inv wb.create --client anthropic              # Create all workbooks with anthropic
-    inv wb.run -c 4                           # Run with concurrency=4
-    inv wb.run --parallel                     # Run all workbooks in parallel
-    inv wb.all --parallel --client gemini      # Full pipeline with gemini client
-    inv wb.basic -c 2 --client anthropic     # Run basic workbook with anthropic
+    inv wb.basic --explain                          # Preview execution plan (no API calls)
+    inv wb.max -c 2 --client gemini                 # Run max workbook with gemini, concurrency 2
+    inv wb.create --parallel                        # Create all workbooks in parallel
+    inv wb.all --parallel --client gemini           # Full pipeline with gemini client
+    inv explain ./workbooks/my_prompts.xlsx         # Preview any workbook's execution DAG
 
 SCREENING EXAMPLES:
-    inv screening.run -r ./resumes/ -j ./jd.md                    # Create and run
-    inv screening.run -r ./resumes/ -j ./jd.md --planning         # Planning mode
-    inv screening.create -r ./resumes/ -j ./jd.md -o ./out.xlsx   # Create only
+    inv screening.run --resumes-path ./resumes/ --jd ./jd.md
+    inv screening.run --resumes-path ./resumes/ --jd ./jd.md --planning
+    inv screening.manifest --resumes-path ./resumes/ --jd ./jd.md
+    inv screening.create --jd ./jd.md --output ./template.xlsx
 
 CONFIGURATION:
-    Workbook paths and client configurations are loaded from config/test.yaml
-    Access via: config.sample.workbooks.basic, config.sample.sample_clients, etc.
+    Settings are loaded from config/main.yaml and config/clients.yaml.
+    Use 'inv config-check' to display current values.
+    Use 'inv --help <task>' to see all arguments for any specific task.
 """)
 
 
@@ -1274,7 +1277,7 @@ screening.add_task(screening_manifest, name="manifest")
 
 # Root namespace
 ns = Collection()
-ns.add_task(help)
+ns.add_task(guide)
 ns.add_task(config_check, name="config-check")
 ns.add_task(explain)
 ns.add_task(lint)

--- a/tests/test_results_frame.py
+++ b/tests/test_results_frame.py
@@ -311,6 +311,7 @@ class TestResultsFrameScoresPivot:
         assert "batch_name" in pivot.columns
         assert "rank" in pivot.columns
         assert "percentile" in pivot.columns
+        assert "percent_rank" in pivot.columns
 
     def test_pivot_returns_empty_for_no_normalized_criteria(self):
         from src.orchestrator.results import ResultsFrame

--- a/tests/test_results_frame.py
+++ b/tests/test_results_frame.py
@@ -415,6 +415,259 @@ class TestResultsFrameScoresPivot:
         assert "raw_years" not in names
 
 
+class TestResultsFrameCompositePipeline:
+    """Tests for composite score computation via Polars pipeline."""
+
+    def _criteria(self, names: list[str] | None = None) -> list[dict]:
+        if names is None:
+            names = ["skills"]
+        return [
+            {
+                "criteria_name": n,
+                "description": f"{n} desc",
+                "scale_min": 1,
+                "scale_max": 10,
+                "weight": 1.0,
+                "source_prompt": "eval",
+                "score_type": "normalized_score",
+            }
+            for n in names
+        ]
+
+    def _get_composite(self, pivot: pl.DataFrame, name: str) -> dict:
+        row = pivot.filter(
+            (pl.col("criteria_name") == "_composite") & (pl.col("batch_name") == name)
+        )
+        return {
+            "rank": row["rank"].item(),
+            "percentile": row["percentile"].item(),
+            "percent_rank": row["percent_rank"].item(),
+            "weighted_score": row["weighted_score"].item(),
+        }
+
+    def test_composite_dense_rank_distinct_scores(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=9.0
+            ),
+            _make_result(batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=6.0),
+            _make_result(
+                batch_id=3, batch_name="carol", scores={"skills": 3.0}, composite_score=3.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        assert self._get_composite(pivot, "alice")["rank"] == 1
+        assert self._get_composite(pivot, "bob")["rank"] == 2
+        assert self._get_composite(pivot, "carol")["rank"] == 3
+
+    def test_composite_dense_rank_tied_scores(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=7.0
+            ),
+            _make_result(batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=7.0),
+            _make_result(
+                batch_id=3, batch_name="carol", scores={"skills": 3.0}, composite_score=4.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        assert self._get_composite(pivot, "alice")["rank"] == 1
+        assert self._get_composite(pivot, "bob")["rank"] == 1
+        assert self._get_composite(pivot, "carol")["rank"] == 2
+
+    def test_composite_percentile_distinct_scores(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=9.0
+            ),
+            _make_result(batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=6.0),
+            _make_result(
+                batch_id=3, batch_name="carol", scores={"skills": 3.0}, composite_score=3.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        assert self._get_composite(pivot, "alice")["percentile"] == 100
+        assert self._get_composite(pivot, "bob")["percentile"] == 50
+        assert self._get_composite(pivot, "carol")["percentile"] == 0
+
+    def test_composite_percentile_tied_scores(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=7.0
+            ),
+            _make_result(batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=7.0),
+            _make_result(
+                batch_id=3, batch_name="carol", scores={"skills": 3.0}, composite_score=4.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        assert self._get_composite(pivot, "alice")["percentile"] == 100
+        assert self._get_composite(pivot, "bob")["percentile"] == 100
+        assert self._get_composite(pivot, "carol")["percentile"] == 50
+
+    def test_composite_percent_rank_distinct_scores(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=9.0
+            ),
+            _make_result(batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=6.0),
+            _make_result(
+                batch_id=3, batch_name="carol", scores={"skills": 3.0}, composite_score=3.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        assert self._get_composite(pivot, "alice")["percent_rank"] == 100
+        assert self._get_composite(pivot, "bob")["percent_rank"] == 50
+        assert self._get_composite(pivot, "carol")["percent_rank"] == 0
+
+    def test_composite_percent_rank_tied_scores(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=7.0
+            ),
+            _make_result(batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=7.0),
+            _make_result(
+                batch_id=3, batch_name="carol", scores={"skills": 3.0}, composite_score=4.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        assert self._get_composite(pivot, "alice")["percent_rank"] == 50
+        assert self._get_composite(pivot, "bob")["percent_rank"] == 50
+        assert self._get_composite(pivot, "carol")["percent_rank"] == 0
+
+    def test_composite_single_candidate(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=8.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        c = self._get_composite(pivot, "alice")
+        assert c["rank"] == 1
+        assert c["percentile"] == 100
+        assert c["percent_rank"] == 100
+
+    def test_composite_two_candidates_distinct(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=9.0
+            ),
+            _make_result(batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=4.0),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        assert self._get_composite(pivot, "alice")["rank"] == 1
+        assert self._get_composite(pivot, "alice")["percentile"] == 100
+        assert self._get_composite(pivot, "alice")["percent_rank"] == 100
+        assert self._get_composite(pivot, "bob")["rank"] == 2
+        assert self._get_composite(pivot, "bob")["percentile"] == 0
+        assert self._get_composite(pivot, "bob")["percent_rank"] == 0
+
+    def test_composite_null_scores_excluded(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=8.0
+            ),
+            _make_result(
+                batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=None
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        composites = pivot.filter(pl.col("criteria_name") == "_composite")
+        assert composites.height == 1
+        assert composites["batch_name"].to_list() == ["alice"]
+
+    def test_composite_weighted_score_preserved(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=7.5
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        c = self._get_composite(pivot, "alice")
+        assert c["weighted_score"] == 7.5
+
+    def test_composite_metadata_columns_null(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=8.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        row = pivot.filter(
+            (pl.col("criteria_name") == "_composite") & (pl.col("batch_name") == "alice")
+        )
+        assert row["normalized_score"].item() is None
+        assert row["weight"].item() is None
+        assert row["scale_min"].item() is None
+        assert row["scale_max"].item() is None
+        assert "Weighted composite" in str(row["description"].item())
+
+    def test_composite_all_tied_same_rank(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 5.0}, composite_score=6.0
+            ),
+            _make_result(batch_id=2, batch_name="bob", scores={"skills": 5.0}, composite_score=6.0),
+            _make_result(
+                batch_id=3, batch_name="carol", scores={"skills": 5.0}, composite_score=6.0
+            ),
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(self._criteria())
+
+        for name in ["alice", "bob", "carol"]:
+            c = self._get_composite(pivot, name)
+            assert c["rank"] == 1
+            assert c["percentile"] == 100
+            assert c["percent_rank"] == 0
+
+
 class TestResultsFrameByBatch:
     """Tests for ResultsFrame.by_batch()."""
 

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -345,6 +345,23 @@ class TestSynthesisExecutorGetEntryName:
         }
         assert executor.get_entry_name(entry) == "Alice Chen"
 
+    def test_name_from_data_column_with_observability_fields(self):
+        from src.orchestrator.synthesis import SynthesisExecutor
+
+        executor = SynthesisExecutor()
+        entry = {
+            "batch_id": 1,
+            "batch_name": "siddhartha_vasudeva",
+            "candidate_name": "Siddhartha Vasudeva",
+            "input_tokens": 846,
+            "output_tokens": 937,
+            "total_tokens": 1783,
+            "cost_usd": 0.0002175,
+            "duration_ms": 7474.08,
+            "scores": {},
+        }
+        assert executor.get_entry_name(entry) == "Siddhartha Vasudeva"
+
     def test_fallback_to_batch_name(self):
         from src.orchestrator.synthesis import SynthesisExecutor
 

--- a/tests/test_workbook_parser.py
+++ b/tests/test_workbook_parser.py
@@ -650,6 +650,7 @@ class TestWorkbookParserWriteScoresPivot:
             "weighted_score",
             "rank",
             "percentile",
+            "percent_rank",
             "scale_min",
             "scale_max",
             "description",
@@ -668,6 +669,7 @@ class TestWorkbookParserWriteScoresPivot:
                     "weighted_score": ws.cell(row=row, column=5).value,
                     "rank": ws.cell(row=row, column=6).value,
                     "percentile": ws.cell(row=row, column=7).value,
+                    "percent_rank": ws.cell(row=row, column=8).value,
                 }
             )
 
@@ -678,6 +680,7 @@ class TestWorkbookParserWriteScoresPivot:
         assert rows_data[0]["weighted_score"] == 8.0
         assert rows_data[0]["rank"] == 1
         assert rows_data[0]["percentile"] == 100
+        assert rows_data[0]["percent_rank"] == 100
         assert rows_data[1]["batch_name"] == "alice_chen"
         assert rows_data[1]["criteria_name"] == "education"
         assert rows_data[1]["normalized_score"] == 7.0
@@ -685,6 +688,7 @@ class TestWorkbookParserWriteScoresPivot:
         assert rows_data[1]["weighted_score"] == pytest.approx(5.6)
         assert rows_data[1]["rank"] == 1
         assert rows_data[1]["percentile"] == 100
+        assert rows_data[1]["percent_rank"] == 100
         assert rows_data[2]["batch_name"] == "bob_martinez"
         assert rows_data[2]["criteria_name"] == "skills_match"
         assert rows_data[2]["normalized_score"] == 5.0
@@ -692,20 +696,24 @@ class TestWorkbookParserWriteScoresPivot:
         assert rows_data[2]["weighted_score"] == 5.0
         assert rows_data[2]["rank"] == 2
         assert rows_data[2]["percentile"] == 0
+        assert rows_data[2]["percent_rank"] == 0
         assert rows_data[3]["batch_name"] == "bob_martinez"
         assert rows_data[3]["criteria_name"] == "education"
         assert rows_data[3]["rank"] == 2
         assert rows_data[3]["percentile"] == 0
+        assert rows_data[3]["percent_rank"] == 0
         assert rows_data[4]["batch_name"] == "alice_chen"
         assert rows_data[4]["criteria_name"] == "_composite"
         assert rows_data[4]["weighted_score"] == 7.5
         assert rows_data[4]["rank"] == 1
         assert rows_data[4]["percentile"] == 100
+        assert rows_data[4]["percent_rank"] == 100
         assert rows_data[5]["batch_name"] == "bob_martinez"
         assert rows_data[5]["criteria_name"] == "_composite"
         assert rows_data[5]["weighted_score"] == 5.5
         assert rows_data[5]["rank"] == 2
         assert rows_data[5]["percentile"] == 0
+        assert rows_data[5]["percent_rank"] == 0
 
     def test_pivot_returns_none_when_no_normalized_criteria(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
@@ -870,28 +878,38 @@ class TestWorkbookParserWriteScoresPivot:
                 "normalized_score": ws.cell(row=row, column=3).value,
                 "rank": ws.cell(row=row, column=6).value,
                 "percentile": ws.cell(row=row, column=7).value,
+                "percent_rank": ws.cell(row=row, column=8).value,
             }
 
         assert rows_by_key[("alice", "python")]["rank"] == 1
         assert rows_by_key[("alice", "python")]["percentile"] == 100
+        assert rows_by_key[("alice", "python")]["percent_rank"] == 100
         assert rows_by_key[("bob", "python")]["rank"] == 2
         assert rows_by_key[("bob", "python")]["percentile"] == 50
+        assert rows_by_key[("bob", "python")]["percent_rank"] == 0
         assert rows_by_key[("carol", "python")]["rank"] == 2
         assert rows_by_key[("carol", "python")]["percentile"] == 50
+        assert rows_by_key[("carol", "python")]["percent_rank"] == 0
 
         assert rows_by_key[("bob", "docker")]["rank"] == 1
         assert rows_by_key[("bob", "docker")]["percentile"] == 100
+        assert rows_by_key[("bob", "docker")]["percent_rank"] == 100
         assert rows_by_key[("alice", "docker")]["rank"] == 2
         assert rows_by_key[("alice", "docker")]["percentile"] == 50
+        assert rows_by_key[("alice", "docker")]["percent_rank"] == 0
         assert rows_by_key[("carol", "docker")]["rank"] == 2
         assert rows_by_key[("carol", "docker")]["percentile"] == 50
+        assert rows_by_key[("carol", "docker")]["percent_rank"] == 0
 
         assert rows_by_key[("alice", "_composite")]["rank"] == 1
         assert rows_by_key[("alice", "_composite")]["percentile"] == 100
+        assert rows_by_key[("alice", "_composite")]["percent_rank"] == 50
         assert rows_by_key[("bob", "_composite")]["rank"] == 1
         assert rows_by_key[("bob", "_composite")]["percentile"] == 100
+        assert rows_by_key[("bob", "_composite")]["percent_rank"] == 50
         assert rows_by_key[("carol", "_composite")]["rank"] == 2
         assert rows_by_key[("carol", "_composite")]["percentile"] == 50
+        assert rows_by_key[("carol", "_composite")]["percent_rank"] == 0
 
     def test_pivot_deduplicates_per_batch(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
@@ -932,6 +950,8 @@ class TestWorkbookParserWriteScoresPivot:
         assert ws.cell(row=2, column=2).value == "skills_match"
         assert ws.cell(row=2, column=6).value == 1
         assert ws.cell(row=2, column=7).value == 100
+        assert ws.cell(row=2, column=8).value == 100
         assert ws.cell(row=3, column=2).value == "_composite"
         assert ws.cell(row=3, column=6).value == 1
         assert ws.cell(row=3, column=7).value == 100
+        assert ws.cell(row=3, column=8).value == 100


### PR DESCRIPTION
## Summary

- **Rename `inv help` → `inv guide`** to avoid collision with invoke's built-in `--help` flag; update guide content to reflect current task signatures and options (`--explain`, `screening.manifest`, etc.)
- **Add `percent_rank` column to `scores_pivot`** showing fraction of candidates with strictly lower scores (percent_rank semantics), alongside existing dense-rank-based `percentile` column
- **Fix synthesis entry name detection** — observability columns (`input_tokens`, `output_tokens`, etc.) were being picked as the "name" instead of `candidate_name`, causing LLM to see numeric IDs instead of names
- **Refactor composite score building** from imperative Python loops to pure Polars pipeline, unifying rank/percentile/percent_rank logic with the criteria path (eliminates a bug class from dual implementations)
- **Add 12 targeted tests** for composite score pipeline covering dense rank, percentile, percent_rank, ties, nulls, single candidate, and metadata
- **Clarify dependency edges documentation** in README
- **Add git operations section to AGENTS.md** instructing agents not to commit/push/submit PRs without explicit user request

## Test plan

- [x] All 1834 existing tests pass
- [x] 12 new composite pipeline tests pass
- [x] `ruff check` and `ruff format` clean
- [x] Pre-commit hooks pass