### PR TITLE
feat: scoring enhancements — weight tiers, labels, fallback client, synthesis resilience

### DIFF
--- a/config/clients.yaml
+++ b/config/clients.yaml
@@ -64,6 +64,8 @@ client_types:
     provider_prefix: "mistral/"
     api_key_env: "MISTRAL_API_KEY"
     default_model: "mistral-small-latest"
+    fallbacks:
+      - "openai/gpt-4o-mini"
 
   litellm-mistral-large:
     client_class: "FFLiteLLMClient"

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -223,6 +223,9 @@ evaluation:
   default_strategy: "balanced"
   scoring_failure_threshold: 0.5
   max_synthesis_context_chars: 30000
+  weight_tier_enabled: true
+  weight_tier_num_tiers: 3
+  weight_tier_prefix: "tier_"
   strategies:
     potential:
       description: "Hire for promise and growth trajectory"

--- a/config/prompts/screening_planning.yaml
+++ b/config/prompts/screening_planning.yaml
@@ -20,9 +20,17 @@ prompts:
       1. Identify 4-6 key evaluation criteria for screening candidates.
          For each criterion, provide: criteria_name (snake_case), description,
          scale_min (always 1), scale_max (always 10), weight (0.5-2.0 based on
-         importance), and source_prompt (the prompt_name that will extract this score).
+         importance), source_prompt (the prompt_name that will extract this score),
+         and label_1 (requirement type).
 
-      2. Create an evaluation prompt template for each criterion. Each prompt must:
+      2. For each criterion, assign a label_1 value indicating the type of
+         requirement:
+         - technical: Technical skill, tool, language, or framework
+         - education: Degree, certification, or academic requirement
+         - experience: Years of experience or career-level requirement
+         - domain: Industry or domain expertise
+
+      3. Create an evaluation prompt template for each criterion. Each prompt must:
          - Include the template variable candidate_name wrapped in double curly
            braces (the orchestrator will substitute the actual candidate name at runtime)
          - Reference the job description via references: ["job_description"]
@@ -42,6 +50,8 @@ prompts:
         in the prompts array.
       - Each evaluation prompt must instruct the LLM to return a JSON object
         with the criteria_name as a top-level key containing the numeric score.
+      - Every criterion MUST have a label_1 field set to one of: technical,
+        education, experience, or domain.
     references: '["job_description"]'
     notes: "Master generator: derives criteria and evaluation prompts from JD"
     phase: planning
@@ -57,6 +67,9 @@ prompts:
       - Reliability: prompts should elicit scores that are reproducible
       - Completeness: ensure all important aspects of the JD are covered
       - Weight balance: weights should reflect the JD's priorities
+      - Label accuracy: every criterion must have label_1 set to one of:
+        technical, education, experience, or domain. Verify the
+        type assignment is correct for each criterion.
 
       Return the updated JSON with the same schema (scoring_criteria + prompts).
       You may add, remove, or modify criteria and prompts.

--- a/config/prompts/screening_skills_planning.yaml
+++ b/config/prompts/screening_skills_planning.yaml
@@ -2,7 +2,7 @@
 # ==========================================
 # Planning-phase prompts that exhaustively decompose a job description
 # into individual per-skill evaluation prompts. Each discrete skill,
-# technology, soft skill, and experience requirement gets its own prompt
+# technology, and experience requirement gets its own prompt
 # and scoring criterion.
 #
 # Used by: create_screening_workbook.py --planning --planning-prompts screening_skills_planning
@@ -54,7 +54,8 @@ prompts:
             "scale_min": 1,
             "scale_max": 10,
             "weight": 2.0,
-            "source_prompt": "evaluate_python"
+            "source_prompt": "evaluate_python",
+            "label_1": "technical"
           },
           {
             "criteria_name": "docker",
@@ -62,7 +63,8 @@ prompts:
             "scale_min": 1,
             "scale_max": 10,
             "weight": 1.5,
-            "source_prompt": "evaluate_docker"
+            "source_prompt": "evaluate_docker",
+            "label_1": "technical"
           }
         ],
         "prompts": [
@@ -93,9 +95,17 @@ prompts:
       - 0.7: Preferred but not required
       - 0.3: Nice-to-have, mentioned in passing
 
+      LABEL_1 GUIDANCE (requirement type):
+      - technical: Technical skill, tool, language, framework, or platform
+      - education: Degree, certification, or academic requirement
+      - experience: Years of experience or career-level requirement
+      - domain: Industry or domain expertise (e.g., healthcare, finance)
+
       CRITICAL RULES:
       - One skill per criterion. Never combine multiple skills into one.
       - Every criterion MUST include weight as a float between 0.3 and 2.0.
+      - Every criterion MUST include label_1 set to one of: technical,
+        education, experience, or domain.
       - Each source_prompt must exactly match a prompt_name in the prompts array.
       - Each prompt text MUST explicitly state the exact JSON key the evaluator
         must use, matching criteria_name exactly. This is the most important rule.
@@ -126,6 +136,9 @@ prompts:
         mentioned in the first paragraph or in a "Required" section should be
         weighted higher than those in "Preferred" or "Nice to have". If a
         criterion is missing its weight, assign one based on JD emphasis.
+      - Label verification: EVERY criterion MUST have label_1 set to one of:
+        technical, education, experience, or domain. Verify the
+        type assignment is correct for each criterion.
       - KEY NAMING: Every prompt MUST explicitly instruct the evaluator to use
         the exact criteria_name as the JSON response key. For example, if
         criteria_name is "python", the prompt text must say:
@@ -154,7 +167,7 @@ prompts:
       Extract from {{candidate_name}}'s resume and return as structured JSON:
       full name, contact info, education history (institution, degree, year),
       employment history (company, title, dates, responsibilities), and
-      a comprehensive skills list organized by category (technical, soft skills,
+      a comprehensive skills list organized by category (technical,
       domain knowledge, certifications, methodologies).
     notes: "Static prompt: extracts structured profile for downstream per-skill evaluation"
 

--- a/scripts/_shared/client.py
+++ b/scripts/_shared/client.py
@@ -70,13 +70,16 @@ def get_client(client_type: str, workbook_config: dict[str, Any]) -> Any:
     if client_type_config.type == "litellm":
         provider_prefix = client_type_config.provider_prefix
         model_string = f"{provider_prefix}{model}" if provider_prefix else model
-        return client_class(
-            model_string=model_string,
-            api_key=api_key,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            system_instructions=system_instructions,
-        )
+        kwargs: dict[str, Any] = {
+            "model_string": model_string,
+            "api_key": api_key,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "system_instructions": system_instructions,
+        }
+        if client_type_config.fallbacks:
+            kwargs["fallbacks"] = client_type_config.fallbacks
+        return client_class(**kwargs)
     else:
         return client_class(
             api_key=api_key,

--- a/scripts/_shared/logging.py
+++ b/scripts/_shared/logging.py
@@ -57,6 +57,9 @@ def setup_logging(
         root_logger.addHandler(console_handler)
 
     if suppress_litellm:
+        import litellm
+
+        litellm.suppress_debug_info = True
         litellm_logger = logging.getLogger("LiteLLM")
         litellm_logger.setLevel(logging.WARNING)
         litellm_logger.propagate = False

--- a/scripts/sample_workbooks/base.py
+++ b/scripts/sample_workbooks/base.py
@@ -243,6 +243,9 @@ DEFAULT_SCORING_HEADERS = [
     "weight",
     "source_prompt",
     "score_type",
+    "label_1",
+    "label_2",
+    "label_3",
 ]
 
 DEFAULT_SYNTHESIS_HEADERS = [

--- a/src/Clients/FFLiteLLMClient.py
+++ b/src/Clients/FFLiteLLMClient.py
@@ -190,7 +190,7 @@ class FFLiteLLMClient(FFAIClientBase):
                 retry_settings, "retry_on_status_codes", [429, 503, 502, 504]
             )
 
-            # Suppress LiteLLM's verbose INFO logging
+            litellm.suppress_debug_info = True
             litellm_logger = logging.getLogger("LiteLLM")
             litellm_logger.setLevel(logging.WARNING)
 
@@ -202,7 +202,7 @@ class FFLiteLLMClient(FFAIClientBase):
         except Exception as e:
             logger.warning(f"Failed to configure LiteLLM retry from config: {e}")
             litellm.num_retries = 3
-            # Still suppress LiteLLM logging even if config fails
+            litellm.suppress_debug_info = True
             litellm_logger = logging.getLogger("LiteLLM")
             litellm_logger.setLevel(logging.WARNING)
 

--- a/src/config.py
+++ b/src/config.py
@@ -353,6 +353,7 @@ class ClientTypeConfig(BaseSettings):
     api_key_env: str = ""
     provider_prefix: str = ""
     default_model: str = ""
+    fallbacks: list[str] = Field(default_factory=list)
 
 
 class ClientsConfig(BaseSettings):
@@ -395,6 +396,9 @@ class EvaluationConfig(BaseSettings):
     scoring_failure_threshold: float = 0.5
     max_synthesis_context_chars: int = 30000
     strategies: dict[str, StrategyConfig] = Field(default_factory=dict)
+    weight_tier_enabled: bool = True
+    weight_tier_num_tiers: int = 3
+    weight_tier_prefix: str = "tier_"
 
     model_config = SettingsConfigDict(extra="ignore")
 

--- a/src/orchestrator/base/orchestrator_base.py
+++ b/src/orchestrator/base/orchestrator_base.py
@@ -935,6 +935,17 @@ class OrchestratorBase(ABC):
         """
         return self._synthesis_runner.resolve_evaluation_strategy(self)
 
+    def _apply_weight_tiers(self) -> None:
+        """Derive weight_tier labels on scoring_rubric from config."""
+        if not self.scoring_rubric:
+            return
+        eval_config = get_config().evaluation
+        if eval_config.weight_tier_enabled:
+            self.scoring_rubric.derive_weight_tiers(
+                num_tiers=eval_config.weight_tier_num_tiers,
+                tier_prefix=eval_config.weight_tier_prefix,
+            )
+
     def _aggregate_scores(self) -> None:
         """Extract scores from batch results and compute composites."""
         self._synthesis_runner.aggregate_scores(self)

--- a/src/orchestrator/client_registry.py
+++ b/src/orchestrator/client_registry.py
@@ -164,6 +164,8 @@ class ClientRegistry:
                 kwargs["api_version"] = config["api_version"]
             if config.get("fallbacks"):
                 kwargs["fallbacks"] = config["fallbacks"]
+            elif client_type_config.fallbacks:
+                kwargs["fallbacks"] = client_type_config.fallbacks
         else:
             if model:
                 kwargs["model"] = model

--- a/src/orchestrator/excel_orchestrator.py
+++ b/src/orchestrator/excel_orchestrator.py
@@ -138,12 +138,16 @@ class ExcelOrchestrator(OrchestratorBase):
                     weight=c["weight"],
                     source_prompt=c["source_prompt"],
                     score_type=c.get("score_type", ""),
+                    label_1=c.get("label_1") or "",
+                    label_2=c.get("label_2") or "",
+                    label_3=c.get("label_3") or "",
                 )
                 for c in scoring_data
             ]
             self.scoring_rubric = ScoringRubric(criteria)
             self.has_scoring = True
             self.evaluation_strategy = self._resolve_evaluation_strategy()
+            self._apply_weight_tiers()
             logger.info(
                 f"Scoring enabled with {len(criteria)} criteria, "
                 f"strategy='{self.evaluation_strategy}'"
@@ -240,8 +244,12 @@ class ExcelOrchestrator(OrchestratorBase):
                     "scale_min": c.scale_min,
                     "scale_max": c.scale_max,
                     "weight": c.weight,
+                    "weight_tier": c.weight_tier,
                     "source_prompt": c.source_prompt,
                     "score_type": c.score_type,
+                    "label_1": c.label_1,
+                    "label_2": c.label_2,
+                    "label_3": c.label_3,
                 }
                 for c in self.scoring_rubric.criteria
             ]

--- a/src/orchestrator/manifest.py
+++ b/src/orchestrator/manifest.py
@@ -446,12 +446,16 @@ class ManifestOrchestrator(OrchestratorBase):
                         weight=c["weight"],
                         source_prompt=c["source_prompt"],
                         score_type=c.get("score_type", ""),
+                        label_1=c.get("label_1") or "",
+                        label_2=c.get("label_2") or "",
+                        label_3=c.get("label_3") or "",
                     )
                     for c in scoring_data
                 ]
                 self.scoring_rubric = ScoringRubric(criteria)
                 self.has_scoring = True
                 self.evaluation_strategy = self._resolve_evaluation_strategy()
+                self._apply_weight_tiers()
                 logger.info(
                     f"Scoring enabled with {len(criteria)} criteria, "
                     f"strategy='{self.evaluation_strategy}'"

--- a/src/orchestrator/planning.py
+++ b/src/orchestrator/planning.py
@@ -417,6 +417,9 @@ class PlanningArtifactParser:
                     weight=weight,
                     source_prompt=c.get("source_prompt", ""),
                     score_type=c.get("score_type", "normalized_score"),
+                    label_1=str(c.get("label_1", "") or "").strip(),
+                    label_2=str(c.get("label_2", "") or "").strip(),
+                    label_3=str(c.get("label_3", "") or "").strip(),
                 )
             )
         return result

--- a/src/orchestrator/planning_runner.py
+++ b/src/orchestrator/planning_runner.py
@@ -253,6 +253,7 @@ class PlanningPhaseRunner:
                     orchestrator.scoring_rubric = ScoringRubric(scoring_criteria_objs)
                     orchestrator.has_scoring = True
                     orchestrator.evaluation_strategy = orchestrator._resolve_evaluation_strategy()
+                    orchestrator._apply_weight_tiers()
                     logger.info(
                         f"Scoring rubric auto-derived from planning phase with "
                         f"{len(valid_criteria)} criteria, "

--- a/src/orchestrator/results/frame.py
+++ b/src/orchestrator/results/frame.py
@@ -52,8 +52,12 @@ RESULTS_COLUMNS: list[str] = [f.name for f in dataclass_fields(PromptResult)]
 PIVOT_COLUMNS = [
     "batch_name",
     "criteria_name",
+    "label_1",
+    "label_2",
+    "label_3",
     "normalized_score",
     "weight",
+    "weight_tier",
     "weighted_score",
     "rank",
     "percentile",
@@ -294,8 +298,12 @@ class ResultsFrame:
                     {
                         "batch_name": batch_name,
                         "criteria_name": cname,
+                        "label_1": crit.get("label_1", ""),
+                        "label_2": crit.get("label_2", ""),
+                        "label_3": crit.get("label_3", ""),
                         "normalized_score": numeric,
                         "weight": weight,
+                        "weight_tier": crit.get("weight_tier", ""),
                         "weighted_score": numeric * weight if numeric is not None else None,
                         "scale_min": crit.get("scale_min", 1),
                         "scale_max": crit.get("scale_max", 10),
@@ -368,8 +376,12 @@ class ResultsFrame:
                 )
                 .with_columns(
                     pl.lit("_composite").alias("criteria_name"),
+                    pl.lit("").alias("label_1"),
+                    pl.lit("").alias("label_2"),
+                    pl.lit("").alias("label_3"),
                     pl.lit(None).cast(pl.Float64).alias("normalized_score"),
                     pl.lit(None).cast(pl.Float64).alias("weight"),
+                    pl.lit("").alias("weight_tier"),
                     pl.lit(None).cast(pl.Int64).alias("scale_min"),
                     pl.lit(None).cast(pl.Int64).alias("scale_max"),
                     pl.lit(

--- a/src/orchestrator/scoring.py
+++ b/src/orchestrator/scoring.py
@@ -31,6 +31,10 @@ class ScoringCriteria:
     weight: float = 1.0
     source_prompt: str = ""
     score_type: str = ""
+    weight_tier: str = ""
+    label_1: str = ""
+    label_2: str = ""
+    label_3: str = ""
 
 
 def extract_score(
@@ -109,6 +113,30 @@ class ScoringRubric:
     def __init__(self, criteria: list[ScoringCriteria]) -> None:
         self.criteria = criteria
         self._criteria_by_name: dict[str, ScoringCriteria] = {c.criteria_name: c for c in criteria}
+
+    def derive_weight_tiers(self, num_tiers: int = 3, tier_prefix: str = "tier_") -> None:
+        """Assign weight_tier to each criterion by ranking distinct weights.
+
+        Unique weight values are sorted descending and split into equal-sized
+        groups. All criteria sharing the same weight receive the same tier.
+
+        Args:
+            num_tiers: Number of tier groups (default 3).
+            tier_prefix: Prefix for tier names (default "tier_").
+
+        """
+        if not self.criteria or num_tiers < 1:
+            return
+
+        unique_weights = sorted({c.weight for c in self.criteria}, reverse=True)
+        n = len(unique_weights)
+        weight_to_tier: dict[float, str] = {}
+        for i, w in enumerate(unique_weights):
+            tier_idx = min(int(i * num_tiers / n), num_tiers - 1)
+            weight_to_tier[w] = f"{tier_prefix}{tier_idx + 1}"
+
+        for criteria in self.criteria:
+            criteria.weight_tier = weight_to_tier.get(criteria.weight, "")
 
     def extract_scores(
         self, results_by_name: dict[str, dict[str, Any]], batch_name: str = ""

--- a/src/orchestrator/synthesis.py
+++ b/src/orchestrator/synthesis.py
@@ -357,7 +357,10 @@ class SynthesisExecutor:
             if available <= 20:
                 break
 
-            if response_text and len(response_text) > available:
+            if not response_text:
+                blocks.append(f"<{tag}>\n[no response]\n</{tag}>")
+                used += len(tag) + 30
+            elif len(response_text) > available:
                 truncated_text = response_text[: available - 30]
                 blocks.append(
                     f"<{tag}>\n{truncated_text}\n[...truncated at {available} chars...]\n</{tag}>"

--- a/src/orchestrator/workbook_parser.py
+++ b/src/orchestrator/workbook_parser.py
@@ -224,6 +224,9 @@ class WorkbookParser:
         "weight",
         "source_prompt",
         "score_type",
+        "label_1",
+        "label_2",
+        "label_3",
     ]
 
     SYNTHESIS_HEADERS = [
@@ -846,6 +849,9 @@ class WorkbookParser:
                         "weight": float(weight),
                         "source_prompt": str(row_data.get("source_prompt", "")).strip(),
                         "score_type": str(row_data.get("score_type", "")).strip(),
+                        "label_1": str(row_data.get("label_1", "")).strip(),
+                        "label_2": str(row_data.get("label_2", "")).strip(),
+                        "label_3": str(row_data.get("label_3", "")).strip(),
                     }
                 )
 

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -158,7 +158,10 @@ class TestExecutePlanningPhase:
             mock_planning_config.continue_on_parse_error = True
             mock_planning_config.generated_sequence_base = "auto"
             mock_planning_config.generated_sequence_step = 10
+            mock_eval_config = MagicMock()
+            mock_eval_config.weight_tier_enabled = False
             mock_config.return_value.planning = mock_planning_config
+            mock_config.return_value.evaluation = mock_eval_config
 
             orch._execute_planning_phase()
 

--- a/tests/test_planning_artifact_parser.py
+++ b/tests/test_planning_artifact_parser.py
@@ -526,3 +526,35 @@ class TestBuildScoringCriteria:
         ]
         result = parser.build_scoring_criteria(criteria_dicts)
         assert result[0].score_type == "custom_type"
+
+    def test_labels_extracted(self):
+        parser = PlanningArtifactParser()
+        criteria_dicts = [
+            {
+                "criteria_name": "python",
+                "description": "Python proficiency",
+                "scale_min": 1,
+                "scale_max": 10,
+                "weight": 2.0,
+                "source_prompt": "eval_python",
+                "label_1": "technical",
+                "label_2": "hard_skill",
+            }
+        ]
+        result = parser.build_scoring_criteria(criteria_dicts)
+        assert result[0].label_1 == "technical"
+        assert result[0].label_2 == "hard_skill"
+        assert result[0].label_3 == ""
+
+    def test_labels_default_empty(self):
+        parser = PlanningArtifactParser()
+        criteria_dicts = [
+            {
+                "criteria_name": "x",
+                "description": "X",
+            }
+        ]
+        result = parser.build_scoring_criteria(criteria_dicts)
+        assert result[0].label_1 == ""
+        assert result[0].label_2 == ""
+        assert result[0].label_3 == ""

--- a/tests/test_results_frame.py
+++ b/tests/test_results_frame.py
@@ -667,6 +667,76 @@ class TestResultsFrameCompositePipeline:
             assert c["percentile"] == 100
             assert c["percent_rank"] == 0
 
+    def test_labels_in_pivot(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"python": 8.0}, composite_score=8.0
+            ),
+        ]
+        criteria = [
+            {
+                "criteria_name": "python",
+                "description": "Python proficiency",
+                "scale_min": 1,
+                "scale_max": 10,
+                "weight": 2.0,
+                "source_prompt": "eval",
+                "score_type": "normalized_score",
+                "label_1": "technical",
+                "label_2": "hard_skill",
+                "label_3": "",
+                "weight_tier": "tier_1",
+            }
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(criteria)
+
+        assert "label_1" in pivot.columns
+        assert "label_2" in pivot.columns
+        assert "label_3" in pivot.columns
+        assert "weight_tier" in pivot.columns
+
+        python_row = pivot.filter(pl.col("criteria_name") == "python")
+        assert python_row["label_1"].item() == "technical"
+        assert python_row["label_2"].item() == "hard_skill"
+        assert python_row["label_3"].item() == ""
+        assert python_row["weight_tier"].item() == "tier_1"
+
+        composite_row = pivot.filter(pl.col("criteria_name") == "_composite")
+        assert composite_row["label_1"].item() == ""
+        assert composite_row["label_2"].item() == ""
+        assert composite_row["weight_tier"].item() == ""
+
+    def test_labels_default_empty_in_pivot(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1, batch_name="alice", scores={"skills": 8.0}, composite_score=8.0
+            ),
+        ]
+        criteria = [
+            {
+                "criteria_name": "skills",
+                "description": "Skills",
+                "scale_min": 1,
+                "scale_max": 10,
+                "weight": 1.0,
+                "source_prompt": "eval",
+                "score_type": "normalized_score",
+            }
+        ]
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(criteria)
+
+        row = pivot.filter(pl.col("criteria_name") == "skills")
+        assert row["label_1"].item() == ""
+        assert row["label_2"].item() == ""
+        assert row["label_3"].item() == ""
+        assert row["weight_tier"].item() == ""
+
 
 class TestResultsFrameByBatch:
     """Tests for ResultsFrame.by_batch()."""

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -570,3 +570,49 @@ class TestResultBuilderScoring:
         assert result.response == "ok"
         assert result.scores == {"a": 9}
         assert result.strategy == "potential"
+
+
+class TestDeriveWeightTiers:
+    def test_three_tiers_five_weights(self):
+        criteria = [
+            ScoringCriteria(criteria_name=f"w{w}", description="", weight=w)
+            for w in [2.0, 1.5, 1.0, 0.7, 0.3]
+        ]
+        rubric = ScoringRubric(criteria)
+        rubric.derive_weight_tiers(num_tiers=3)
+        tiers = {c.criteria_name: c.weight_tier for c in rubric.criteria}
+        assert tiers["w2.0"] == "tier_1"
+        assert tiers["w1.5"] == "tier_1"
+        assert tiers["w1.0"] == "tier_2"
+        assert tiers["w0.7"] == "tier_2"
+        assert tiers["w0.3"] == "tier_3"
+
+    def test_same_weight_same_tier(self):
+        criteria = [
+            ScoringCriteria(criteria_name="a", description="", weight=1.5),
+            ScoringCriteria(criteria_name="b", description="", weight=1.5),
+            ScoringCriteria(criteria_name="c", description="", weight=0.7),
+        ]
+        rubric = ScoringRubric(criteria)
+        rubric.derive_weight_tiers(num_tiers=2)
+        assert rubric.criteria[0].weight_tier == rubric.criteria[1].weight_tier
+
+    def test_custom_prefix(self):
+        criteria = [
+            ScoringCriteria(criteria_name="a", description="", weight=2.0),
+            ScoringCriteria(criteria_name="b", description="", weight=1.0),
+        ]
+        rubric = ScoringRubric(criteria)
+        rubric.derive_weight_tiers(num_tiers=2, tier_prefix="priority_")
+        assert rubric.criteria[0].weight_tier == "priority_1"
+        assert rubric.criteria[1].weight_tier == "priority_2"
+
+    def test_empty_criteria(self):
+        rubric = ScoringRubric([])
+        rubric.derive_weight_tiers()
+
+    def test_single_weight(self):
+        criteria = [ScoringCriteria(criteria_name="a", description="", weight=1.0)]
+        rubric = ScoringRubric(criteria)
+        rubric.derive_weight_tiers(num_tiers=3)
+        assert rubric.criteria[0].weight_tier == "tier_1"

--- a/tests/test_workbook_parser.py
+++ b/tests/test_workbook_parser.py
@@ -645,8 +645,12 @@ class TestWorkbookParserWriteScoresPivot:
         assert headers == [
             "batch_name",
             "criteria_name",
+            "label_1",
+            "label_2",
+            "label_3",
             "normalized_score",
             "weight",
+            "weight_tier",
             "weighted_score",
             "rank",
             "percentile",
@@ -664,12 +668,12 @@ class TestWorkbookParserWriteScoresPivot:
                 {
                     "batch_name": ws.cell(row=row, column=1).value,
                     "criteria_name": ws.cell(row=row, column=2).value,
-                    "normalized_score": ws.cell(row=row, column=3).value,
-                    "weight": ws.cell(row=row, column=4).value,
-                    "weighted_score": ws.cell(row=row, column=5).value,
-                    "rank": ws.cell(row=row, column=6).value,
-                    "percentile": ws.cell(row=row, column=7).value,
-                    "percent_rank": ws.cell(row=row, column=8).value,
+                    "normalized_score": ws.cell(row=row, column=6).value,
+                    "weight": ws.cell(row=row, column=7).value,
+                    "weighted_score": ws.cell(row=row, column=9).value,
+                    "rank": ws.cell(row=row, column=10).value,
+                    "percentile": ws.cell(row=row, column=11).value,
+                    "percent_rank": ws.cell(row=row, column=12).value,
                 }
             )
 
@@ -810,12 +814,12 @@ class TestWorkbookParserWriteScoresPivot:
         ws = wb[sheet_name]
         assert ws.max_row == 3
         assert ws.cell(row=2, column=2).value == "skills_match"
-        assert ws.cell(row=2, column=6).value == 1
-        assert ws.cell(row=2, column=7).value == 100
+        assert ws.cell(row=2, column=10).value == 1
+        assert ws.cell(row=2, column=11).value == 100
         assert ws.cell(row=3, column=2).value == "_composite"
-        assert ws.cell(row=3, column=5).value == 8.0
-        assert ws.cell(row=3, column=6).value == 1
-        assert ws.cell(row=3, column=7).value == 100
+        assert ws.cell(row=3, column=9).value == 8.0
+        assert ws.cell(row=3, column=10).value == 1
+        assert ws.cell(row=3, column=11).value == 100
 
     def test_pivot_per_criteria_ranking(self, temp_workbook_with_data):
         from src.orchestrator.workbook_parser import WorkbookParser
@@ -875,10 +879,10 @@ class TestWorkbookParserWriteScoresPivot:
             bn = ws.cell(row=row, column=1).value
             cn = ws.cell(row=row, column=2).value
             rows_by_key[(bn, cn)] = {
-                "normalized_score": ws.cell(row=row, column=3).value,
-                "rank": ws.cell(row=row, column=6).value,
-                "percentile": ws.cell(row=row, column=7).value,
-                "percent_rank": ws.cell(row=row, column=8).value,
+                "normalized_score": ws.cell(row=row, column=6).value,
+                "rank": ws.cell(row=row, column=10).value,
+                "percentile": ws.cell(row=row, column=11).value,
+                "percent_rank": ws.cell(row=row, column=12).value,
             }
 
         assert rows_by_key[("alice", "python")]["rank"] == 1
@@ -948,10 +952,10 @@ class TestWorkbookParserWriteScoresPivot:
         ws = wb[sheet_name]
         assert ws.max_row == 3
         assert ws.cell(row=2, column=2).value == "skills_match"
-        assert ws.cell(row=2, column=6).value == 1
-        assert ws.cell(row=2, column=7).value == 100
-        assert ws.cell(row=2, column=8).value == 100
+        assert ws.cell(row=2, column=10).value == 1
+        assert ws.cell(row=2, column=11).value == 100
+        assert ws.cell(row=2, column=12).value == 100
         assert ws.cell(row=3, column=2).value == "_composite"
-        assert ws.cell(row=3, column=6).value == 1
-        assert ws.cell(row=3, column=7).value == 100
-        assert ws.cell(row=3, column=8).value == 100
+        assert ws.cell(row=3, column=10).value == 1
+        assert ws.cell(row=3, column=11).value == 100
+        assert ws.cell(row=3, column=12).value == 100


### PR DESCRIPTION
## Summary

- **Weight tier derivation**: Auto-derive `weight_tier` (tier_1/tier_2/tier_3) from scoring criteria weights by ranking distinct weight values into configurable N tiers. Keeps tier always consistent with weight, eliminating LLM-driven tier assignment conflicts.
- **Generic label fields**: Add `label_1`, `label_2`, `label_3` fields to `ScoringCriteria` for LLM-driven categorization. Screening prompts now instruct the LLM to populate `label_1` with requirement type (technical, education, experience, domain).
- **LLM fallback client**: Add `fallbacks` config to `ClientTypeConfig` and wire through client registry and script factory. Default client (`litellm-mistral-small`) now falls back to `openai/gpt-4o-mini` on Mistral API failures.
- **Synthesis resilience**: Fix `TypeError` in `_format_response_blocks` when batch prompts fail and responses are `None`.
- **Prompt cleanup**: Remove soft skill references from all screening prompts.
- **LiteLLM noise**: Set `litellm.suppress_debug_info = True` in client and CLI logging.

## Changes

| Commit | Description |
|--------|-------------|
| `c4eebac` | Add `weight_tier`, `label_1/2/3` fields, `derive_weight_tiers()`, `_apply_weight_tiers()` helper, config settings, pivot column reordering |
| `adee327` | Update screening YAML prompts with label_1=type instructions, remove soft skills |
| `a04f55a` | Handle None responses in synthesis context formatting |
| `9782e5b` | Add fallbacks field to ClientTypeConfig, wire through registry and scripts |
| `88b5817` | Suppress LiteLLM debug output |

## Scores pivot column order (new)

```
batch_name | criteria_name | label_1 | label_2 | label_3 | normalized_score | weight | weight_tier | weighted_score | rank | ...
```

## Config additions (`config/main.yaml`)

```yaml
evaluation:
  weight_tier_enabled: true
  weight_tier_num_tiers: 3
  weight_tier_prefix: "tier_"
```

## Config additions (`config/clients.yaml`)

```yaml
litellm-mistral-small:
  fallbacks:
    - "openai/gpt-4o-mini"
```