### PR TITLE
feat: abort condition, gate evaluation, and structured log context

### DIFF
--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -7,7 +7,7 @@ logging:
   directory: "logs"
   filename: "orchestrator.log"
   level: "INFO"
-  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  format: "%(asctime)s - %(name)s - %(levelname)s - batch=%(batch_name)s prompt=%(prompt_name)s - %(message)s"
   rotation:
     when: "midnight"
     interval: 1

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -126,6 +126,8 @@ workbook:
 orchestrator:
   default_concurrency: 2
   max_concurrency: 10
+  abort:
+    response_default: "-1"
 
 document_processor:
   checksum_length: 8

--- a/config/prompts/screening_planning.yaml
+++ b/config/prompts/screening_planning.yaml
@@ -89,6 +89,37 @@ prompts:
     references: '["job_description"]'
     notes: "Static prompt: extracts structured profile for downstream evaluation"
 
+  - sequence: 150
+    prompt_name: gate_evaluation
+    prompt: |
+      Based on the profile extracted from {{candidate_name}}'s resume below,
+      perform a quick screening check against the job description.
+
+      Determine whether this candidate meets the MINIMUM qualifications for the
+      role. Consider:
+
+      1. Required years of experience — does the candidate have enough?
+      2. Required education — does the candidate meet the minimum degree?
+      3. Core domain — is the candidate in a broadly relevant field?
+      4. Deal-breakers — are there fundamental mismatches (e.g., entry-level
+         candidate for a senior role, unrelated industry with no transferable skills)?
+
+      Be GENEROUS in borderline cases. Only reject candidates who clearly do not
+      meet the minimum bar. When in doubt, set proceed to true and let the
+      detailed evaluation make the final call.
+
+      Return ONLY a JSON object:
+      {"proceed": true, "reason": "Candidate meets minimum qualifications"}
+      or
+      {"proceed": false, "reason": "<specific reason for rejection>"}
+    history: '["extract_profile"]'
+    references: '["job_description"]'
+    abort_condition: 'json_get({{gate_evaluation.response}}, "proceed") == False'
+    notes: >
+      Gate prompt: quickly screens out clearly unqualified candidates before
+      expensive per-skill evaluation. If proceed=false, all remaining prompts
+      for this candidate are aborted.
+
   - sequence: 200
     prompt_name: overall_assessment
     prompt: |

--- a/config/prompts/screening_skills_planning.yaml
+++ b/config/prompts/screening_skills_planning.yaml
@@ -171,6 +171,37 @@ prompts:
       domain knowledge, certifications, methodologies).
     notes: "Static prompt: extracts structured profile for downstream per-skill evaluation"
 
+  - sequence: 150
+    prompt_name: gate_evaluation
+    prompt: |
+      Based on the profile extracted from {{candidate_name}}'s resume below,
+      perform a quick screening check against the job description.
+
+      Determine whether this candidate meets the MINIMUM qualifications for the
+      role. Consider:
+
+      1. Required years of experience — does the candidate have enough?
+      2. Required education — does the candidate meet the minimum degree?
+      3. Core domain — is the candidate in a broadly relevant field?
+      4. Deal-breakers — are there fundamental mismatches (e.g., entry-level
+         candidate for a senior role, unrelated industry with no transferable skills)?
+
+      Be GENEROUS in borderline cases. Only reject candidates who clearly do not
+      meet the minimum bar. When in doubt, set proceed to true and let the
+      detailed evaluation make the final call.
+
+      Return ONLY a JSON object:
+      {"proceed": true, "reason": "Candidate meets minimum qualifications"}
+      or
+      {"proceed": false, "reason": "<specific reason for rejection>"}
+    history: '["extract_profile"]'
+    references: '["job_description"]'
+    abort_condition: 'json_get({{gate_evaluation.response}}, "proceed") == False'
+    notes: >
+      Gate prompt: quickly screens out clearly unqualified candidates before
+      expensive per-skill evaluation. If proceed=false, all remaining prompts
+      for this candidate are aborted.
+
   - sequence: 200
     prompt_name: overall_assessment
     prompt: |

--- a/config/prompts/screening_static.yaml
+++ b/config/prompts/screening_static.yaml
@@ -20,6 +20,37 @@ prompts:
       technical skills list.
     references: '["job_description"]'
 
+  - sequence: 15
+    prompt_name: gate_evaluation
+    prompt: |
+      Based on the profile extracted from {{candidate_name}}'s resume below,
+      perform a quick screening check against the job description.
+
+      Determine whether this candidate meets the MINIMUM qualifications for the
+      role. Consider:
+
+      1. Required years of experience — does the candidate have enough?
+      2. Required education — does the candidate meet the minimum degree?
+      3. Core domain — is the candidate in a broadly relevant field?
+      4. Deal-breakers — are there fundamental mismatches (e.g., entry-level
+         candidate for a senior role, unrelated industry with no transferable skills)?
+
+      Be GENEROUS in borderline cases. Only reject candidates who clearly do not
+      meet the minimum bar. When in doubt, set proceed to true and let the
+      detailed evaluation make the final call.
+
+      Return ONLY a JSON object:
+      {"proceed": true, "reason": "Candidate meets minimum qualifications"}
+      or
+      {"proceed": false, "reason": "<specific reason for rejection>"}
+    history: '["extract_profile"]'
+    references: '["job_description"]'
+    abort_condition: 'json_get({{gate_evaluation.response}}, "proceed") == False'
+    notes: >
+      Gate prompt: quickly screens out clearly unqualified candidates before
+      detailed evaluation. If proceed=false, all remaining prompts for this
+      candidate are aborted.
+
   - sequence: 20
     prompt_name: evaluate_skills
     prompt: |

--- a/convenience/screening.sh
+++ b/convenience/screening.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SIZE="${1:-}"
+case "$SIZE" in
+  small)  RESUMES="./library/resumes_small/" ;;
+  medium) RESUMES="./library/resumes_medium/" ;;
+  "")     RESUMES="./library/resumes/" ;;
+  *)
+    echo "Usage: $0 [small|medium]"
+    echo "  (no argument = full resume set)"
+    exit 1
+    ;;
+esac
+WORKBOOK="screening_$(date +%Y%m%d%H%M%S).xlsx"
+python scripts/create_screening_workbook.py "./$WORKBOOK" \
+  --jd ./library/job_descriptions/Sample_JD_Google_Data_Engineer.md \
+  --resumes-path "$RESUMES" \
+  --planning \
+  --planning-prompts screening_skills_planning \
+  --synthesis-prompts screening_synthesis
+python scripts/run_orchestrator.py "./$WORKBOOK" -c 5

--- a/scripts/_shared/__init__.py
+++ b/scripts/_shared/__init__.py
@@ -8,4 +8,4 @@ from .client import get_client, get_client_class
 from .logging import setup_logging
 from .progress import ProgressIndicator
 
-__all__ = ["setup_logging", "get_client", "get_client_class", "ProgressIndicator"]
+__all__ = ["ProgressIndicator", "get_client", "get_client_class", "setup_logging"]

--- a/scripts/_shared/logging.py
+++ b/scripts/_shared/logging.py
@@ -24,6 +24,8 @@ def setup_logging(
         Configured logger instance.
 
     """
+    from src.observability.log_context import ContextFormatter, LogContextFilter
+
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG if verbose else logging.INFO)
 
@@ -38,6 +40,10 @@ def setup_logging(
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, log_config.filename)
 
+    context_filter = LogContextFilter()
+    root_logger.addFilter(context_filter)
+    formatter = ContextFormatter(log_config.format)
+
     file_handler = TimedRotatingFileHandler(
         log_file,
         when=log_config.rotation.when,
@@ -47,13 +53,13 @@ def setup_logging(
     )
     file_handler.suffix = "%Y-%m-%d"
     file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(logging.Formatter(log_config.format))
+    file_handler.setFormatter(formatter)
     root_logger.addHandler(file_handler)
 
     if not quiet:
         console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setLevel(logging.INFO)
-        console_handler.setFormatter(logging.Formatter(log_config.format))
+        console_handler.setFormatter(formatter)
         root_logger.addHandler(console_handler)
 
     if suppress_litellm:

--- a/scripts/manifest_run.py
+++ b/scripts/manifest_run.py
@@ -301,6 +301,7 @@ def main():
     print(f"Concurrency:   {args.concurrency}")
     print(f"Total prompts: {summary['total_prompts']}")
     print(f"Successful:    {summary['successful']}")
+    print(f"Aborted:       {summary['aborted']}")
     print(f"Failed:        {summary['failed']}")
     print("=" * 60 + "\n")
 

--- a/scripts/run_orchestrator.py
+++ b/scripts/run_orchestrator.py
@@ -264,6 +264,7 @@ def main():
     print(f"Concurrency:   {args.concurrency}")
     print(f"Total prompts: {summary['total_prompts']}")
     print(f"Successful:    {summary['successful']}")
+    print(f"Aborted:       {summary['aborted']}")
     print(f"Failed:        {summary['failed']}")
     print("=" * 60 + "\n")
 

--- a/scripts/sample_workbooks/base.py
+++ b/scripts/sample_workbooks/base.py
@@ -56,6 +56,7 @@ class PromptSpec:
     max_tool_rounds: int | None = None
     validation_prompt: str | None = None
     max_validation_retries: int | None = None
+    abort_condition: str | None = None
     phase: str | None = None
     generator: str | None = None
 
@@ -82,6 +83,7 @@ class PromptSpec:
             "max_tool_rounds": self.max_tool_rounds or "",
             "validation_prompt": self.validation_prompt or "",
             "max_validation_retries": self.max_validation_retries or "",
+            "abort_condition": self.abort_condition or "",
             "phase": self.phase or "",
             "generator": self.generator or "",
         }
@@ -161,6 +163,7 @@ DEFAULT_PROMPT_HEADERS = [
     "max_tool_rounds",
     "validation_prompt",
     "max_validation_retries",
+    "abort_condition",
     "phase",
     "generator",
 ]
@@ -183,8 +186,9 @@ DEFAULT_PROMPT_COLUMN_WIDTHS = {
     "O": 18,
     "P": 18,
     "Q": 20,
-    "R": 12,
+    "R": 60,
     "S": 12,
+    "T": 12,
 }
 
 DEFAULT_CONFIG_COLUMN_WIDTHS = {

--- a/scripts/sample_workbooks/screening.py
+++ b/scripts/sample_workbooks/screening.py
@@ -64,6 +64,25 @@ def get_static_screening_prompts(
     )
     prompts.append(
         PromptSpec(
+            15,
+            "gate_evaluation",
+            "Based on the profile extracted from {{candidate_name}}'s resume, "
+            "perform a quick screening check against the job description. "
+            "Determine whether this candidate meets the MINIMUM qualifications. "
+            "Consider: required years of experience, required education, "
+            "core domain relevance, and fundamental deal-breakers (e.g., "
+            "entry-level candidate for a senior role, unrelated industry). "
+            "Be GENEROUS in borderline cases — only reject candidates who "
+            "clearly do not meet the minimum bar. When in doubt, proceed=true. "
+            'Return ONLY JSON: {"proceed": true/false, "reason": "..."}',
+            history='["extract_profile"]',
+            references='["job_description"]',
+            abort_condition='json_get({{gate_evaluation.response}}, "proceed") == False',
+            notes="Gate: quickly screens out clearly unqualified candidates before detailed evaluation",
+        )
+    )
+    prompts.append(
+        PromptSpec(
             20,
             "evaluate_skills",
             "Evaluate {{candidate_name}}'s technical skills against the job description. "
@@ -225,6 +244,26 @@ def get_planning_screening_prompts(
             "technical skills list.",
             references='["job_description"]',
             notes="Static prompt: extracts structured profile for downstream evaluation",
+        )
+    )
+
+    prompts.append(
+        PromptSpec(
+            150,
+            "gate_evaluation",
+            "Based on the profile extracted from {{candidate_name}}'s resume, "
+            "perform a quick screening check against the job description. "
+            "Determine whether this candidate meets the MINIMUM qualifications. "
+            "Consider: required years of experience, required education, "
+            "core domain relevance, and fundamental deal-breakers (e.g., "
+            "entry-level candidate for a senior role, unrelated industry). "
+            "Be GENEROUS in borderline cases — only reject candidates who "
+            "clearly do not meet the minimum bar. When in doubt, proceed=true. "
+            'Return ONLY JSON: {"proceed": true/false, "reason": "..."}',
+            history='["extract_profile"]',
+            references='["job_description"]',
+            abort_condition='json_get({{gate_evaluation.response}}, "proceed") == False',
+            notes="Gate: quickly screens out clearly unqualified candidates before detailed evaluation",
         )
     )
 
@@ -442,6 +481,7 @@ def prompt_spec_to_dict(spec: PromptSpec) -> dict[str, Any]:
         "notes": spec.notes,
         "client": spec.client,
         "condition": spec.condition,
+        "abort_condition": spec.abort_condition,
         "references": _parse_json_field(spec.references),
         "semantic_query": spec.semantic_query,
         "semantic_filter": _parse_json_field(spec.semantic_filter),

--- a/scripts/try_ai_mistralsmall_script.py
+++ b/scripts/try_ai_mistralsmall_script.py
@@ -316,7 +316,7 @@ if not history_df.is_empty():
         logger.info(response_lengths)
 
     except Exception as e:
-        logger.error(f"Error in response length analysis: {str(e)}")
+        logger.error(f"Error in response length analysis: {e!s}")
 
     logger.info(
         "============================================================================================================================================================================="
@@ -344,6 +344,6 @@ if not history_df.is_empty():
             plt.savefig("response_length_by_prompt.png")
             logger.info("Plot saved to 'response_length_by_prompt.png'")
     except Exception as e:
-        logger.error(f"Error creating visualization: {str(e)}")
+        logger.error(f"Error creating visualization: {e!s}")
 
 logger.info("Script execution completed")

--- a/scripts/validate_native_observability.py
+++ b/scripts/validate_native_observability.py
@@ -16,7 +16,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from src.config import get_config
 from src.orchestrator.manifest import ManifestOrchestrator
 
 MANIFEST_DIR = "./manifest_samples/observability_native_clients"
@@ -104,7 +103,7 @@ def validate_usage(client, client_name):
             print(f"  [WARN] Output tokens is 0 for {client_name}")
             return False
 
-        print(f"  [OK] Token usage extracted successfully")
+        print("  [OK] Token usage extracted successfully")
         return True
 
     except Exception as e:
@@ -151,9 +150,9 @@ def validate_manifest_run(client, client_name):
             return False
 
         if total_input > 0 or total_output > 0:
-            print(f"  [OK] Token tracking working in orchestrator")
+            print("  [OK] Token tracking working in orchestrator")
         else:
-            print(f"  [WARN] No tokens tracked in orchestrator summary")
+            print("  [WARN] No tokens tracked in orchestrator summary")
 
         return True
 
@@ -183,12 +182,12 @@ def main():
             continue
 
         # Step 1: Direct usage validation
-        print(f"  [Test 1] Direct generate_response() usage extraction:")
+        print("  [Test 1] Direct generate_response() usage extraction:")
         usage_ok = validate_usage(client, name)
         print()
 
         # Step 2: Manifest orchestrator run
-        print(f"  [Test 2] Manifest orchestrator run:")
+        print("  [Test 2] Manifest orchestrator run:")
         clone = client.clone()
         manifest_ok = validate_manifest_run(clone, name)
 

--- a/src/Clients/FFGemini.py
+++ b/src/Clients/FFGemini.py
@@ -178,8 +178,6 @@ class FFGemini(FFAIClientBase):
         tool_choice: str | None = None,
         **kwargs,
     ) -> str:
-        logger.debug(f"Generating response for prompt: {prompt}")
-
         if not prompt.strip():
             logger.error("Received empty prompt")
             raise ValueError("Prompt cannot be empty")

--- a/src/Clients/FFMistral.py
+++ b/src/Clients/FFMistral.py
@@ -169,8 +169,6 @@ class FFMistral(FFAIClientBase):
         if not prompt.strip():
             raise ValueError("Empty prompt provided")
 
-        logger.debug(f"Generating response for prompt: {prompt}")
-
         self._reset_usage()
 
         # Parameter normalization

--- a/src/Clients/FFMistralSmall.py
+++ b/src/Clients/FFMistralSmall.py
@@ -175,8 +175,6 @@ class FFMistralSmall(FFAIClientBase):
         if not prompt.strip():
             raise ValueError("Empty prompt provided")
 
-        logger.debug(f"Generating response for prompt: {prompt}")
-
         self._reset_usage()
 
         # Parameter normalization

--- a/src/Clients/FFPerplexity.py
+++ b/src/Clients/FFPerplexity.py
@@ -140,8 +140,6 @@ class FFPerplexity(FFAIClientBase):
         if not prompt.strip():
             raise ValueError("Empty prompt provided")
 
-        logger.debug(f"Generating response for prompt: {prompt}")
-
         self._reset_usage()
 
         used_model = model or self.model or "sonar"

--- a/src/FFAI.py
+++ b/src/FFAI.py
@@ -190,7 +190,11 @@ class FFAI:
         logger.debug(
             "\n==================================================================================="
         )
-        logger.info(f"Generating response for prompt: '{prompt}'")
+        prompt_preview = prompt[:80] + "..." if len(prompt) > 80 else prompt
+        logger.info(
+            f"Generating response for '{prompt_name}' ({len(prompt)} chars): '{prompt_preview}'"
+        )
+        logger.debug(f"Full prompt: '{prompt}'")
         logger.debug(f"Prompt_name: '{prompt_name}'")
         logger.debug(
             f"System instructions: '{system_instructions}'"

--- a/src/config.py
+++ b/src/config.py
@@ -175,11 +175,18 @@ class WorkbookConfig(BaseSettings):
     formatting: WorkbookFormattingConfig = Field(default_factory=WorkbookFormattingConfig)
 
 
+class OrchestratorAbortConfig(BaseSettings):
+    """Abort condition configuration."""
+
+    response_default: str = "-1"
+
+
 class OrchestratorConfig(BaseSettings):
     """Orchestrator configuration."""
 
     default_concurrency: int = 2
     max_concurrency: int = 10
+    abort: OrchestratorAbortConfig = Field(default_factory=OrchestratorAbortConfig)
 
 
 class RetryConfig(BaseSettings):

--- a/src/core/prompt_builder.py
+++ b/src/core/prompt_builder.py
@@ -55,8 +55,8 @@ class PromptBuilder:
             logger.debug("No history provided, checking for interpolation only")
             history = []
 
-        logger.info(f"Building prompt with history references: {history}")
-        logger.info(f"Current history size: {len(self._prompt_attr_history)}")
+        logger.debug(f"Building prompt with history references: {history}")
+        logger.debug(f"Current history size: {len(self._prompt_attr_history)}")
 
         for idx, entry in enumerate(self._prompt_attr_history):
             logger.debug("==================================================================")
@@ -147,5 +147,6 @@ class PromptBuilder:
         else:
             final_prompt = resolved_prompt
 
-        logger.info(f"Final constructed prompt:\n{final_prompt}")
+        logger.info(f"Final prompt constructed ({len(final_prompt)} chars)")
+        logger.debug(f"Final constructed prompt:\n{final_prompt}")
         return final_prompt, interpolated_names

--- a/src/observability/log_context.py
+++ b/src/observability/log_context.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+"""Thread-local logging context for batch_name and prompt_name."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_batch_name: ContextVar[str] = ContextVar("batch_name", default="-")
+_prompt_name: ContextVar[str] = ContextVar("prompt_name", default="-")
+
+
+def set_log_context(batch_name: str | None = None, prompt_name: str | None = None) -> None:
+    if batch_name is not None:
+        _batch_name.set(batch_name)
+    if prompt_name is not None:
+        _prompt_name.set(prompt_name)
+
+
+def clear_log_context() -> None:
+    _batch_name.set("-")
+    _prompt_name.set("-")
+
+
+@contextmanager
+def log_context(batch_name: str | None = None, prompt_name: str | None = None):
+    tokens = []
+    if batch_name is not None:
+        tokens.append((_batch_name, _batch_name.set(batch_name)))
+    if prompt_name is not None:
+        tokens.append((_prompt_name, _prompt_name.set(prompt_name)))
+    try:
+        yield
+    finally:
+        for var, token in tokens:
+            var.reset(token)
+
+
+class LogContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.batch_name = _batch_name.get()
+        record.prompt_name = _prompt_name.get()
+        return True
+
+
+class ContextFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        record.batch_name = getattr(record, "batch_name", _batch_name.get())
+        record.prompt_name = getattr(record, "prompt_name", _prompt_name.get())
+        return super().format(record)

--- a/src/orchestrator/base/orchestrator_base.py
+++ b/src/orchestrator/base/orchestrator_base.py
@@ -30,6 +30,7 @@ from ...core.client_base import FFAIClientBase
 from ...core.response_context import ResponseContext
 from ...FFAI import FFAI
 from ...observability import get_telemetry_manager
+from ...observability.log_context import log_context
 from ..agent_executor import AgentExecutor
 from ..client_registry import ClientRegistry
 from ..document_processor import DocumentProcessor
@@ -643,6 +644,28 @@ class OrchestratorBase(ABC):
             Result dictionary.
 
         """
+        p_name = prompt.get("prompt_name", "-")
+        with log_context(batch_name=batch_name or "-", prompt_name=p_name):
+            return self._execute_with_retry_inner(
+                prompt,
+                results_by_name,
+                results_lock,
+                batch_id,
+                batch_name,
+                batch_history,
+                batch_history_lock,
+            )
+
+    def _execute_with_retry_inner(
+        self,
+        prompt: PromptSpec,
+        results_by_name: dict[str, dict[str, Any]],
+        results_lock: threading.Lock | None,
+        batch_id: int | None,
+        batch_name: str | None,
+        batch_history: list[Interaction] | None,
+        batch_history_lock: threading.Lock | None,
+    ) -> dict[str, Any]:
         max_retries = self.config.get("max_retries", 3)
         retry_base_delay = self.config.get("retry_base_delay", 1.0)
 

--- a/src/orchestrator/base/orchestrator_base.py
+++ b/src/orchestrator/base/orchestrator_base.py
@@ -35,7 +35,7 @@ from ..client_registry import ClientRegistry
 from ..document_processor import DocumentProcessor
 from ..document_registry import DocumentRegistry
 from ..executor import Executor
-from ..graph import build_execution_graph, evaluate_condition, get_ready_prompts
+from ..graph import build_execution_graph, evaluate_condition, get_ready_prompts, is_abort_trigger
 from ..models import ConfigSpec, DocumentSpec, Interaction, PromptSpec
 from ..planning_runner import PlanningPhaseRunner
 from ..results import ResultBuilder, ResultsFrame
@@ -524,9 +524,9 @@ class OrchestratorBase(ABC):
         self, prompt: PromptSpec, results_by_name: dict[str, dict[str, Any]]
     ) -> tuple[bool, str | None, str | None, str | None]:
         """Evaluate a prompt's condition and return the resolved trace."""
-        from ..graph import evaluate_condition_with_trace
+        from ..graph import evaluate_condition_with_trace as _eval
 
-        return evaluate_condition_with_trace(prompt, results_by_name)
+        return _eval(prompt, results_by_name)
 
     def _execute_agent_mode(
         self,
@@ -577,6 +577,43 @@ class OrchestratorBase(ABC):
                 batch_history_lock=batch_history_lock,
             ),
         )
+
+    def _evaluate_abort_condition(
+        self,
+        prompt: PromptSpec,
+        results_by_name: dict[str, dict[str, Any]],
+    ) -> tuple[bool, str | None]:
+        """Evaluate a prompt's abort_condition after successful execution.
+
+        The abort_condition uses the same syntax and evaluation engine as
+        the condition field, but is checked AFTER execution rather than before.
+        If True, all remaining prompts in the current scope should be
+        short-circuited with status='aborted'.
+
+        Note: evaluate_condition_with_trace returns (should_execute, ...) where
+        True means "the condition passed." For abort_condition, a passing
+        condition means "abort" — so should_abort=True = abort triggered.
+
+        Args:
+            prompt: Prompt dictionary with optional abort_condition.
+            results_by_name: Results indexed by prompt_name. Must include
+                this prompt's own result so the condition can reference it.
+
+        Returns:
+            Tuple of (abort_triggered, abort_trace). abort_triggered is True
+            if the abort_condition is present and evaluates to True.
+
+        """
+        abort_condition = prompt.get("abort_condition")
+        if not abort_condition or not str(abort_condition).strip():
+            return False, None
+
+        from ..graph import evaluate_condition_with_trace
+
+        condition_passed, _, _, abort_trace = evaluate_condition_with_trace(
+            prompt, results_by_name, condition_field="abort_condition"
+        )
+        return condition_passed, abort_trace
 
     def _execute_with_retry(
         self,
@@ -731,7 +768,22 @@ class OrchestratorBase(ABC):
                         logger.info(f"Retrying {seq_label} in {delay:.1f}s")
                         time.sleep(delay)
 
-        return builder.build_dict()
+            result_dict = builder.build_dict()
+
+            if result_dict["status"] == "success":
+                temp_results = dict(results_by_name)
+                prompt_name = prompt.get("prompt_name")
+                if prompt_name:
+                    temp_results[prompt_name] = result_dict
+                abort_triggered, abort_trace = self._evaluate_abort_condition(prompt, temp_results)
+                if abort_triggered:
+                    builder.with_abort_triggered(abort_trace)
+                    result_dict = builder.build_dict()
+                    prompt_span.set_attribute("prompt.abort_triggered", True)
+                    prompt_span.set_attribute("prompt.abort_trace", abort_trace)
+                    logger.info(f"{seq_label} abort triggered: {abort_trace}")
+
+        return result_dict
 
     def _execute_prompt_core(
         self,
@@ -808,6 +860,11 @@ class OrchestratorBase(ABC):
         """Generate batch name from data row or default."""
         return resolve_batch_name(data_row, batch_id)
 
+    def _get_abort_response(self) -> str:
+        """Get the configured response value for aborted prompts."""
+        config = get_config()
+        return config.orchestrator.abort.response_default
+
     def _execute_single_batch(
         self,
         batch_id: int,
@@ -831,8 +888,22 @@ class OrchestratorBase(ABC):
         """
         results: list[dict[str, Any]] = []
         results_by_name: dict[str, dict[str, Any]] = {}
+        aborted = False
+        abort_response = self._get_abort_response()
 
         for prompt in self.prompts:
+            if aborted:
+                result = (
+                    ResultBuilder(prompt)
+                    .with_batch(batch_id, batch_name)
+                    .as_aborted(response=abort_response)
+                    .build_dict()
+                )
+                results.append(result)
+                if result.get("prompt_name"):
+                    results_by_name[result["prompt_name"]] = result
+                continue
+
             resolved_prompt = self._resolve_prompt_variables(prompt, data_row)
 
             result = self._execute_prompt_with_batch(
@@ -847,6 +918,15 @@ class OrchestratorBase(ABC):
 
             if result.get("prompt_name"):
                 results_by_name[result["prompt_name"]] = result
+
+            if is_abort_trigger(result):
+                aborted = True
+                logger.info(
+                    f"Batch {batch_id} abort triggered by "
+                    f"'{result.get('prompt_name', 'unknown')}', "
+                    f"skipping {len(self.prompts) - len(results)} remaining prompts"
+                )
+                continue
 
             if result["status"] == "failed":
                 on_error = self.config.get("on_batch_error", "continue")

--- a/src/orchestrator/executor.py
+++ b/src/orchestrator/executor.py
@@ -16,6 +16,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
+from .graph import is_abort_trigger
 from .results import ResultBuilder
 from .state import ExecutionState, PromptNode
 
@@ -58,6 +59,8 @@ class Executor:
         results: list[dict[str, Any]] = []
         results_by_name: dict[str, dict[str, Any]] = {}
         total = len(orchestrator.prompts)
+        aborted = False
+        abort_response = orchestrator._get_abort_response()
 
         nodes = orchestrator._build_execution_graph()
         ready = [node for node in nodes.values() if not node.dependencies]
@@ -69,6 +72,23 @@ class Executor:
             if node.sequence in executed:
                 continue
             prompt = node.prompt
+
+            if aborted:
+                result = ResultBuilder(prompt).as_aborted(response=abort_response).build_dict()
+                results.append(result)
+                if result.get("prompt_name"):
+                    results_by_name[result["prompt_name"]] = result
+                executed.add(node.sequence)
+                for candidate in nodes.values():
+                    if candidate.sequence in executed:
+                        continue
+                    if candidate.sequence in {n.sequence for n in ready}:
+                        continue
+                    if candidate.dependencies.issubset(executed):
+                        ready.append(candidate)
+                ready.sort(key=lambda n: (n.level, n.sequence))
+                continue
+
             if orchestrator.progress_callback:
                 orchestrator.progress_callback(
                     len(results),
@@ -85,6 +105,13 @@ class Executor:
 
             if result.get("prompt_name"):
                 results_by_name[result["prompt_name"]] = result
+
+            if is_abort_trigger(result):
+                aborted = True
+                logger.info(
+                    f"Abort triggered by '{result.get('prompt_name', 'unknown')}', "
+                    f"aborting {total - len(results)} remaining prompts"
+                )
 
             for candidate in nodes.values():
                 if candidate.sequence in executed:
@@ -123,6 +150,7 @@ class Executor:
         nodes = orchestrator._build_execution_graph()
         state = ExecutionState(pending=dict(nodes))
         total = len(nodes)
+        abort_response = orchestrator._get_abort_response()
 
         def update_progress() -> None:
             if orchestrator.progress_callback:
@@ -139,6 +167,24 @@ class Executor:
 
         with ThreadPoolExecutor(max_workers=orchestrator.concurrency) as executor:
             while len(state.completed) < total:
+                if state.aborted:
+                    for seq, node in nodes.items():
+                        if seq not in state.completed and seq not in state.in_progress:
+                            aborted_result = (
+                                ResultBuilder(node.prompt)
+                                .as_aborted(response=abort_response)
+                                .build_dict()
+                            )
+                            with state.results_lock:
+                                state.results.append(aborted_result)
+                                state.completed.add(seq)
+                                state.aborted_count += 1
+                                if aborted_result.get("prompt_name"):
+                                    state.results_by_name[aborted_result["prompt_name"]] = (
+                                        aborted_result
+                                    )
+                    break
+
                 ready = orchestrator._get_ready_prompts(state, nodes)
 
                 if not ready and not state.in_progress:
@@ -166,6 +212,13 @@ class Executor:
                             self._update_state_counts(state, result)
                             if result.get("prompt_name"):
                                 state.results_by_name[result["prompt_name"]] = result
+                            if is_abort_trigger(result):
+                                state.aborted = True
+                                logger.info(
+                                    f"Abort triggered by "
+                                    f"'{result.get('prompt_name', 'unknown')}', "
+                                    f"aborting remaining prompts"
+                                )
                     except Exception as e:
                         logger.error(f"Unexpected error for sequence {seq}: {e}")
                         self._handle_execution_error(state, nodes[seq], str(e))
@@ -178,6 +231,7 @@ class Executor:
         logger.info(
             f"Parallel execution complete: {state.success_count} succeeded, "
             f"{state.failed_count} failed, {state.skipped_count} skipped"
+            + (f", {state.aborted_count} aborted" if state.aborted_count else "")
         )
 
         return state.results
@@ -260,8 +314,22 @@ class Executor:
             batch_results_by_name: dict[str, dict[str, Any]] = {}
             batch_history: list[dict[str, Any]] = list(base_history_snapshot)
             batch_history_lock = threading.Lock()
+            aborted = False
+            abort_response = orchestrator._get_abort_response()
 
             for prompt in orchestrator.prompts:
+                if aborted:
+                    result = (
+                        ResultBuilder(prompt)
+                        .with_batch(batch_idx, batch_name)
+                        .as_aborted(response=abort_response)
+                        .build_dict()
+                    )
+                    batch_results.append(result)
+                    if result.get("prompt_name"):
+                        batch_results_by_name[result["prompt_name"]] = result
+                    continue
+
                 resolved_prompt = orchestrator._resolve_prompt_variables(prompt, data_row)
 
                 result = orchestrator._execute_prompt_with_batch(
@@ -276,6 +344,15 @@ class Executor:
 
                 if result.get("prompt_name"):
                     batch_results_by_name[result["prompt_name"]] = result
+
+                if is_abort_trigger(result):
+                    aborted = True
+                    logger.info(
+                        f"Batch {batch_idx} abort triggered by "
+                        f"'{result.get('prompt_name', 'unknown')}', "
+                        f"skipping {len(orchestrator.prompts) - len(batch_results)} remaining prompts"
+                    )
+                    continue
 
                 if result["status"] == "failed":
                     on_error = orchestrator.config.get("on_batch_error", "continue")
@@ -342,6 +419,8 @@ class Executor:
             state.success_count += 1
         elif result["status"] == "skipped":
             state.skipped_count += 1
+        elif result["status"] == "aborted":
+            state.aborted_count += 1
         else:
             state.failed_count += 1
 
@@ -359,6 +438,8 @@ class Executor:
         successful = sum(1 for r in results if r["status"] == "success")
         failed = sum(1 for r in results if r["status"] == "failed")
         skipped = sum(1 for r in results if r["status"] == "skipped")
+        aborted = sum(1 for r in results if r["status"] == "aborted")
         logger.info(
-            f"{prefix} complete: {successful} succeeded, {failed} failed, {skipped} skipped"
+            f"{prefix} complete: {successful} succeeded, {failed} failed, "
+            f"{skipped} skipped" + (f", {aborted} aborted" if aborted else "")
         )

--- a/src/orchestrator/explain.py
+++ b/src/orchestrator/explain.py
@@ -185,6 +185,13 @@ def _format_dag(plan: ExplainPlan) -> str:
                     cond_str = cond_str[:47] + "..."
                 annotations.append(f"cond: {cond_str}")
 
+            abort_condition = p.get("abort_condition")
+            if abort_condition:
+                ac_str = str(abort_condition)
+                if len(ac_str) > 50:
+                    ac_str = ac_str[:47] + "..."
+                annotations.append(f"abort: {ac_str}")
+
             agent = p.get("agent_mode")
             if agent:
                 tools = p.get("tools") or []

--- a/src/orchestrator/graph.py
+++ b/src/orchestrator/graph.py
@@ -26,8 +26,8 @@ class DependencyEdge:
     Attributes:
         from_seq: Sequence number of the dependency (upstream prompt).
         to_seq: Sequence number of the dependent (downstream prompt).
-        source: How the edge was derived — 'history' or 'condition'.
-        condition_text: The condition expression (only set when source='condition').
+        source: How the edge was derived — 'history', 'condition', or 'abort_condition'.
+        condition_text: The condition expression (set when source='condition' or 'abort_condition').
 
     """
 
@@ -127,6 +127,8 @@ def build_execution_graph_with_edges(
         for dep_name, _ in ConditionEvaluator.extract_referenced_names(condition):
             if dep_name in prompt_by_name:
                 dep_seq = prompt_by_name[dep_name]
+                if dep_seq == seq:
+                    continue
                 nodes[seq].dependencies.add(dep_seq)
                 if dep_seq not in seen_condition_deps:
                     seen_condition_deps.add(dep_seq)
@@ -136,6 +138,29 @@ def build_execution_graph_with_edges(
                             to_seq=seq,
                             source="condition",
                             condition_text=str(condition),
+                        )
+                    )
+
+        abort_condition = prompt.get("abort_condition") or ""
+        seen_abort_deps: set[int] = set()
+        for dep_name, _ in ConditionEvaluator.extract_referenced_names(abort_condition):
+            if dep_name in prompt_by_name:
+                dep_seq = prompt_by_name[dep_name]
+                if dep_seq == seq:
+                    # Self-reference is allowed at evaluation time (the prompt
+                    # can test its own response in abort_condition, e.g.
+                    # {{check.response}} == "abort"), but excluded from the
+                    # dependency graph to avoid a false cycle detection.
+                    continue
+                nodes[seq].dependencies.add(dep_seq)
+                if dep_seq not in seen_abort_deps:
+                    seen_abort_deps.add(dep_seq)
+                    edges.append(
+                        DependencyEdge(
+                            from_seq=dep_seq,
+                            to_seq=seq,
+                            source="abort_condition",
+                            condition_text=str(abort_condition),
                         )
                     )
 
@@ -191,18 +216,21 @@ def get_ready_prompts(state: ExecutionState, nodes: dict[int, PromptNode]) -> li
 def evaluate_condition(
     prompt: PromptSpec,
     results_by_name: dict[str, dict[str, Any]],
+    condition_field: str = "condition",
 ) -> tuple[bool, str | None, str | None]:
     """Evaluate a prompt's condition.
 
     Args:
         prompt: Prompt dictionary with optional condition.
         results_by_name: Results indexed by prompt_name.
+        condition_field: Name of the field containing the condition expression.
+            Defaults to "condition". Use "abort_condition" for abort evaluation.
 
     Returns:
         Tuple of (should_execute, condition_result, condition_error).
 
     """
-    condition = prompt.get("condition")
+    condition = prompt.get(condition_field)
 
     if not condition or not str(condition).strip():
         return True, None, None
@@ -216,18 +244,21 @@ def evaluate_condition(
 def evaluate_condition_with_trace(
     prompt: PromptSpec,
     results_by_name: dict[str, dict[str, Any]],
+    condition_field: str = "condition",
 ) -> tuple[bool, str | None, str | None, str | None]:
     """Evaluate a prompt's condition and return the resolved trace.
 
     Args:
         prompt: Prompt dictionary with optional condition.
         results_by_name: Results indexed by prompt_name.
+        condition_field: Name of the field containing the condition expression.
+            Defaults to "condition". Use "abort_condition" for abort evaluation.
 
     Returns:
         Tuple of (should_execute, condition_result, condition_error, condition_trace).
 
     """
-    condition = prompt.get("condition")
+    condition = prompt.get(condition_field)
 
     if not condition or not str(condition).strip():
         return True, None, None, None
@@ -236,3 +267,19 @@ def evaluate_condition_with_trace(
     result, error, trace = evaluator.evaluate_with_trace(str(condition))
 
     return result, result, error, trace
+
+
+def is_abort_trigger(result: dict[str, Any]) -> bool:
+    """Check whether a result triggered an abort.
+
+    A prompt triggers abort when it executed successfully (status='success')
+    and its abort_condition evaluated to True (abort_trace is set).
+
+    Args:
+        result: A result dictionary from prompt execution.
+
+    Returns:
+        True if this result should trigger abort of remaining prompts.
+
+    """
+    return result.get("abort_trace") is not None and result["status"] == "success"

--- a/src/orchestrator/manifest.py
+++ b/src/orchestrator/manifest.py
@@ -177,6 +177,7 @@ class WorkbookManifestExporter:
                 "notes": prompt.get("notes"),
                 "client": prompt.get("client"),
                 "condition": prompt.get("condition"),
+                "abort_condition": prompt.get("abort_condition"),
                 "references": prompt.get("references") or [],
                 "semantic_query": prompt.get("semantic_query"),
                 "semantic_filter": prompt.get("semantic_filter"),

--- a/src/orchestrator/models.py
+++ b/src/orchestrator/models.py
@@ -32,6 +32,7 @@ class PromptSpec(TypedDict, total=False):
     max_tool_rounds: int | None
     validation_prompt: str | None
     max_validation_retries: int | None
+    abort_condition: str | None
     phase: str
     generator: bool
     _generated: bool

--- a/src/orchestrator/planning_runner.py
+++ b/src/orchestrator/planning_runner.py
@@ -17,6 +17,7 @@ import time
 from typing import Any
 
 from ..config import get_config
+from ..observability.log_context import log_context
 from .planning import PlanningArtifactParser
 from .scoring import ScoringRubric
 from .validation import OrchestratorValidator
@@ -97,7 +98,8 @@ class PlanningPhaseRunner:
                     current_name=f"[planning] {prompt_name}",
                 )
 
-            result = orchestrator._execute_prompt(prompt, results_by_name=results_by_name)
+            with log_context(batch_name="-", prompt_name=prompt_name):
+                result = orchestrator._execute_prompt(prompt, results_by_name=results_by_name)
 
             result["result_type"] = "planning"
             result["batch_id"] = None

--- a/src/orchestrator/results/builder.py
+++ b/src/orchestrator/results/builder.py
@@ -340,6 +340,43 @@ class ResultBuilder:
         self._result.batch_name = ""
         return self
 
+    def as_aborted(self, abort_trace: str | None = None, response: str = "-1") -> ResultBuilder:
+        """Mark as aborted due to an upstream abort_condition trigger.
+
+        Sets status to 'aborted', response to the given value (default '-1'),
+        and records the resolved abort condition trace for observability.
+
+        Args:
+            abort_trace: The resolved abort condition expression showing
+                substituted values, or None if no condition to trace.
+            response: The response value for aborted prompts. Defaults to '-1'.
+                Can be customized via config orchestrator.abort.response_default.
+
+        Returns:
+            Self for chaining.
+
+        """
+        self._result.status = "aborted"
+        self._result.response = response
+        self._result.abort_trace = abort_trace
+        return self
+
+    def with_abort_triggered(self, abort_trace: str | None) -> ResultBuilder:
+        """Record that this prompt's abort_condition evaluated to True.
+
+        The prompt itself completed successfully, but its abort condition
+        triggered, so downstream prompts should be short-circuited.
+
+        Args:
+            abort_trace: The resolved abort condition expression.
+
+        Returns:
+            Self for chaining.
+
+        """
+        self._result.abort_trace = abort_trace
+        return self
+
     def build(self) -> PromptResult:
         """Build and return the PromptResult.
 

--- a/src/orchestrator/results/frame.py
+++ b/src/orchestrator/results/frame.py
@@ -177,6 +177,7 @@ class ResultsFrame:
             "successful": status_map.get("success", 0),
             "failed": status_map.get("failed", 0),
             "skipped": status_map.get("skipped", 0),
+            "aborted": status_map.get("aborted", 0),
             "total_attempts": df.select(pl.col("attempts").sum()).item() or 0,
         }
 
@@ -270,19 +271,41 @@ class ResultsFrame:
         if scored.is_empty():
             return pl.DataFrame()
 
+        scored_batch_names = set(scored["batch_name"].to_list())
+
+        aborted_batches: list[str] = []
+        if scored_batch_names:
+            aborted_batches = (
+                self._df.filter(
+                    pl.col("batch_name").is_in(list(scored_batch_names))
+                    & (pl.col("status") == "aborted")
+                )
+                .select("batch_name")
+                .unique()
+                .to_series()
+                .to_list()
+            )
+
         rows: list[dict[str, Any]] = []
         composites: dict[str, float | None] = {}
+        batch_names_with_scores: set[str] = set()
 
         for row_data in scored.iter_rows(named=True):
             batch_name = row_data["batch_name"]
             scores_raw = row_data.get("scores")
-            if not isinstance(scores_raw, str):
-                continue
-            try:
-                scores_dict = json.loads(scores_raw)
-            except (json.JSONDecodeError, TypeError):
-                continue
-            if not isinstance(scores_dict, dict):
+
+            scores_dict: dict[str, Any] | None = None
+            if isinstance(scores_raw, dict):
+                scores_dict = scores_raw
+            elif isinstance(scores_raw, str):
+                try:
+                    parsed = json.loads(scores_raw)
+                    if isinstance(parsed, dict):
+                        scores_dict = parsed
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+            if not scores_dict:
                 continue
 
             composites[batch_name] = row_data.get("composite_score")
@@ -305,6 +328,30 @@ class ResultsFrame:
                         "weight": weight,
                         "weight_tier": crit.get("weight_tier", ""),
                         "weighted_score": numeric * weight if numeric is not None else None,
+                        "scale_min": crit.get("scale_min", 1),
+                        "scale_max": crit.get("scale_max", 10),
+                        "description": crit.get("description", ""),
+                    }
+                )
+                batch_names_with_scores.add(batch_name)
+
+        for batch_name in aborted_batches:
+            if batch_name in batch_names_with_scores:
+                continue
+            composites[batch_name] = -1
+            for cname in criteria_names:
+                crit = criteria_map[cname]
+                rows.append(
+                    {
+                        "batch_name": batch_name,
+                        "criteria_name": cname,
+                        "label_1": crit.get("label_1", ""),
+                        "label_2": crit.get("label_2", ""),
+                        "label_3": crit.get("label_3", ""),
+                        "normalized_score": -1,
+                        "weight": crit.get("weight", 1.0),
+                        "weight_tier": crit.get("weight_tier", ""),
+                        "weighted_score": None,
                         "scale_min": crit.get("scale_min", 1),
                         "scale_max": crit.get("scale_max", 10),
                         "description": crit.get("description", ""),

--- a/src/orchestrator/results/result.py
+++ b/src/orchestrator/results/result.py
@@ -95,8 +95,9 @@ class PromptResult:
     total_tokens: int = 0
     cost_usd: float = 0.0
     duration_ms: float = 0.0
+    abort_trace: str | None = None
 
-    VALID_STATUSES = ("pending", "success", "failed", "skipped", "max_rounds_exceeded")
+    VALID_STATUSES = ("pending", "success", "failed", "skipped", "aborted", "max_rounds_exceeded")
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for backward compatibility."""
@@ -145,4 +146,5 @@ class PromptResult:
             total_tokens=data.get("total_tokens", 0),
             cost_usd=data.get("cost_usd", 0.0),
             duration_ms=data.get("duration_ms", 0.0),
+            abort_trace=data.get("abort_trace"),
         )

--- a/src/orchestrator/scoring.py
+++ b/src/orchestrator/scoring.py
@@ -157,9 +157,9 @@ class ScoringRubric:
 
         for criteria in self.criteria:
             source_result = results_by_name.get(criteria.source_prompt)
-            if source_result is None or source_result.get("status") == "skipped":
+            if source_result is None or source_result.get("status") in ("skipped", "aborted"):
                 skipped.append(criteria.criteria_name)
-                reason = "not found" if source_result is None else "was skipped"
+                reason = "not found" if source_result is None else f"was {source_result['status']}"
                 logger.info(
                     f"Criteria '{criteria.criteria_name}' skipped: "
                     f"source prompt '{criteria.source_prompt}' "

--- a/src/orchestrator/state/execution_state.py
+++ b/src/orchestrator/state/execution_state.py
@@ -26,6 +26,7 @@ class ExecutionState:
         success_count: Number of successful executions.
         failed_count: Number of failed executions.
         skipped_count: Number of skipped executions.
+        aborted_count: Number of aborted executions.
         results_by_name: Results indexed by prompt name.
         current_name: Name of currently executing prompt.
 
@@ -39,5 +40,7 @@ class ExecutionState:
     success_count: int = 0
     failed_count: int = 0
     skipped_count: int = 0
+    aborted_count: int = 0
     results_by_name: dict[str, dict[str, Any]] = field(default_factory=dict)
     current_name: str = ""
+    aborted: bool = False

--- a/src/orchestrator/synthesis_runner.py
+++ b/src/orchestrator/synthesis_runner.py
@@ -16,6 +16,7 @@ import time
 from typing import Any
 
 from ..config import get_config
+from ..observability.log_context import log_context
 from .results import ResultBuilder, ResultsFrame
 from .results.frame import _deserialize_json_columns
 from .scoring import ScoreAggregator
@@ -210,89 +211,113 @@ class SynthesisRunner:
         results_by_name: dict[str, dict[str, Any]] = {}
 
         for synth_prompt in orchestrator.synthesis_prompts:
-            try:
-                source_scope = synth_prompt.get("source_scope", "all")
-                source_prompts = synth_prompt.get("source_prompts", [])
-                include_scores = synth_prompt.get("include_scores", True)
-
-                entries = executor.resolve_source_scope(source_scope, sorted_entries)
-
-                scale_max = 10
-                if orchestrator.scoring_rubric and orchestrator.scoring_rubric.criteria:
-                    scale_max = orchestrator.scoring_rubric.criteria[0].scale_max
-
-                context = executor.format_entry_context(
-                    entries,
-                    source_prompts,
-                    include_scores,
-                    strategy=orchestrator.evaluation_strategy if orchestrator.has_scoring else "",
-                    scale_max=scale_max,
-                )
-
-                resolved_history = ""
-                history_deps = synth_prompt.get("history") or []
-                for dep_name in history_deps:
-                    dep_result = results_by_name.get(dep_name)
-                    if dep_result and dep_result.get("status") == "failed":
-                        logger.warning(
-                            f"Synthesis prompt '{synth_prompt.get('prompt_name')}' "
-                            f"references failed prompt '{dep_name}', "
-                            f"which returned empty response"
-                        )
-                    dep_response = dep_result.get("response", "") if dep_result else ""
-                    resolved_history += f"--- {dep_name} ---\n{dep_response}\n\n"
-                    if dep_result:
-                        orchestrator._response_context.record_raw(dep_result)
-
-                prompt_parts = [context]
-                if resolved_history.strip():
-                    prompt_parts.append(resolved_history.strip())
-                prompt_parts.append(synth_prompt["prompt"])
-                full_prompt = "\n\n===\n\n".join(prompt_parts)
-
-                ffai = orchestrator._get_isolated_ffai(synth_prompt.get("client"))
-                call_start = time.monotonic()
-                synth_result = ffai.generate_response(
-                    prompt=full_prompt,
-                    prompt_name=synth_prompt.get("prompt_name"),
-                )
-                call_duration_ms = (time.monotonic() - call_start) * 1000
-
-                input_tokens = synth_result.usage.input_tokens if synth_result.usage else 0
-                output_tokens = synth_result.usage.output_tokens if synth_result.usage else 0
-                total_tokens = synth_result.usage.total_tokens if synth_result.usage else 0
-                cost_usd = synth_result.cost_usd
-
-                result = _build_synthesis_result(
+            s_name = synth_prompt.get("prompt_name", "-")
+            with log_context(batch_name="-", prompt_name=s_name):
+                self._execute_synthesis_prompt(
                     synth_prompt,
-                    status="success",
-                    evaluation_strategy=orchestrator.evaluation_strategy,
-                    has_scoring=orchestrator.has_scoring,
-                    response=synth_result.response,
-                    resolved_prompt=full_prompt,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    total_tokens=total_tokens,
-                    cost_usd=cost_usd,
-                    duration_ms=call_duration_ms,
+                    orchestrator,
+                    executor,
+                    sorted_entries,
+                    entry_results_map,
+                    criteria_list,
+                    results_by_name,
+                    synthesis_results,
                 )
-
-            except Exception as e:
-                logger.error(
-                    f"Synthesis prompt '{synth_prompt.get('prompt_name')}' failed: {e}",
-                    exc_info=True,
-                )
-                result = _build_synthesis_result(
-                    synth_prompt,
-                    status="failed",
-                    evaluation_strategy=orchestrator.evaluation_strategy,
-                    has_scoring=orchestrator.has_scoring,
-                    error=str(e),
-                )
-
-            synthesis_results.append(result)
-            if result.get("prompt_name"):
-                results_by_name[result["prompt_name"]] = result
 
         orchestrator.results.extend(synthesis_results)
         logger.info(f"Synthesis complete: {len(synthesis_results)} prompts executed")
+
+    def _execute_synthesis_prompt(
+        self,
+        synth_prompt: dict[str, Any],
+        orchestrator: Any,
+        executor: SynthesisExecutor,
+        sorted_entries: list[dict[str, Any]],
+        entry_results_map: dict[int, dict[str, Any]],
+        criteria_list: list[dict[str, Any]],
+        results_by_name: dict[str, dict[str, Any]],
+        synthesis_results: list[dict[str, Any]],
+    ) -> None:
+        try:
+            source_scope = synth_prompt.get("source_scope", "all")
+            source_prompts = synth_prompt.get("source_prompts", [])
+            include_scores = synth_prompt.get("include_scores", True)
+
+            entries = executor.resolve_source_scope(source_scope, sorted_entries)
+
+            scale_max = 10
+            if orchestrator.scoring_rubric and orchestrator.scoring_rubric.criteria:
+                scale_max = orchestrator.scoring_rubric.criteria[0].scale_max
+
+            context = executor.format_entry_context(
+                entries,
+                source_prompts,
+                include_scores,
+                strategy=orchestrator.evaluation_strategy if orchestrator.has_scoring else "",
+                scale_max=scale_max,
+            )
+
+            resolved_history = ""
+            history_deps = synth_prompt.get("history") or []
+            for dep_name in history_deps:
+                dep_result = results_by_name.get(dep_name)
+                if dep_result and dep_result.get("status") == "failed":
+                    logger.warning(
+                        f"Synthesis prompt '{synth_prompt.get('prompt_name')}' "
+                        f"references failed prompt '{dep_name}', "
+                        f"which returned empty response"
+                    )
+                dep_response = dep_result.get("response", "") if dep_result else ""
+                resolved_history += f"--- {dep_name} ---\n{dep_response}\n\n"
+                if dep_result:
+                    orchestrator._response_context.record_raw(dep_result)
+
+            prompt_parts = [context]
+            if resolved_history.strip():
+                prompt_parts.append(resolved_history.strip())
+            prompt_parts.append(synth_prompt["prompt"])
+            full_prompt = "\n\n===\n\n".join(prompt_parts)
+
+            ffai = orchestrator._get_isolated_ffai(synth_prompt.get("client"))
+            call_start = time.monotonic()
+            synth_result = ffai.generate_response(
+                prompt=full_prompt,
+                prompt_name=synth_prompt.get("prompt_name"),
+            )
+            call_duration_ms = (time.monotonic() - call_start) * 1000
+
+            input_tokens = synth_result.usage.input_tokens if synth_result.usage else 0
+            output_tokens = synth_result.usage.output_tokens if synth_result.usage else 0
+            total_tokens = synth_result.usage.total_tokens if synth_result.usage else 0
+            cost_usd = synth_result.cost_usd
+
+            result = _build_synthesis_result(
+                synth_prompt,
+                status="success",
+                evaluation_strategy=orchestrator.evaluation_strategy,
+                has_scoring=orchestrator.has_scoring,
+                response=synth_result.response,
+                resolved_prompt=full_prompt,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=total_tokens,
+                cost_usd=cost_usd,
+                duration_ms=call_duration_ms,
+            )
+
+        except Exception as e:
+            logger.error(
+                f"Synthesis prompt '{synth_prompt.get('prompt_name')}' failed: {e}",
+                exc_info=True,
+            )
+            result = _build_synthesis_result(
+                synth_prompt,
+                status="failed",
+                evaluation_strategy=orchestrator.evaluation_strategy,
+                has_scoring=orchestrator.has_scoring,
+                error=str(e),
+            )
+
+        synthesis_results.append(result)
+        if result.get("prompt_name"):
+            results_by_name[result["prompt_name"]] = result

--- a/src/orchestrator/validation.py
+++ b/src/orchestrator/validation.py
@@ -166,6 +166,7 @@ class OrchestratorValidator:
         self._validate_history_dependencies(result)
         self._validate_template_references(result)
         self._validate_condition_syntax(result)
+        self._validate_abort_condition_syntax(result)
         self._validate_client_assignments(result)
         self._validate_config_values(result)
         self._validate_document_references(result)
@@ -296,6 +297,20 @@ class OrchestratorValidator:
                 result.add_error(
                     "INVALID_CONDITION",
                     f"Condition syntax error: {error_msg}",
+                    prompt_name=prompt.get("prompt_name"),
+                    prompt_sequence=prompt.get("sequence"),
+                )
+
+    def _validate_abort_condition_syntax(self, result: ValidationResult) -> None:
+        for prompt in self.prompts:
+            abort_condition = prompt.get("abort_condition")
+            if not abort_condition or not str(abort_condition).strip():
+                continue
+            is_valid, error_msg = ConditionEvaluator.validate_syntax(abort_condition)
+            if not is_valid:
+                result.add_error(
+                    "INVALID_ABORT_CONDITION",
+                    f"abort_condition syntax error: {error_msg}",
                     prompt_name=prompt.get("prompt_name"),
                     prompt_sequence=prompt.get("sequence"),
                 )

--- a/src/orchestrator/workbook_parser.py
+++ b/src/orchestrator/workbook_parser.py
@@ -173,6 +173,7 @@ class WorkbookParser:
         "notes",
         "client",
         "condition",
+        "abort_condition",
         "references",
         "semantic_query",
         "semantic_filter",
@@ -550,6 +551,9 @@ class WorkbookParser:
                 else None,
                 "condition": str(row_dict.get("condition", "")).strip()
                 if row_dict.get("condition")
+                else None,
+                "abort_condition": str(row_dict.get("abort_condition", "")).strip()
+                if row_dict.get("abort_condition")
                 else None,
                 "references": self._parse_history_string(row_dict.get("references"))
                 if row_dict.get("references")

--- a/src/prompt_templates.py
+++ b/src/prompt_templates.py
@@ -155,6 +155,7 @@ def _dict_to_prompt_spec(data: dict[str, Any]) -> Any:
         "notes",
         "client",
         "condition",
+        "abort_condition",
         "references",
         "semantic_query",
         "semantic_filter",

--- a/tests/test_abort_condition.py
+++ b/tests/test_abort_condition.py
@@ -1,0 +1,665 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+from unittest.mock import MagicMock
+
+from src.FFAIClientBase import FFAIClientBase
+from src.orchestrator.condition_evaluator import ConditionEvaluator
+from src.orchestrator.results.builder import ResultBuilder
+from src.orchestrator.results.result import PromptResult
+
+
+class ScriptedClient(FFAIClientBase):
+    """Client that returns scripted responses in order across all clones."""
+
+    model = "test-model"
+    system_instructions = "test"
+    _shared_responses: list[str]
+    _shared_lock: object
+
+    def __init__(self, responses=None, _shared=None, _lock=None):
+        if _shared is not None:
+            self._shared_responses = _shared
+            self._shared_lock = _lock
+        else:
+            self._shared_responses = list(responses or [])
+            import threading
+
+            self._shared_lock = threading.Lock()
+        self._last_usage = None
+        self._last_cost_usd = 0.0
+        self._conversation_history = []
+
+    def generate_response(self, prompt, **kwargs):
+        with self._shared_lock:
+            if not self._shared_responses:
+                return "default response"
+            resp = self._shared_responses.pop(0)
+        self._conversation_history.append({"role": "user", "content": prompt})
+        self._conversation_history.append({"role": "assistant", "content": resp})
+        return resp
+
+    def clone(self):
+        return ScriptedClient(_shared=self._shared_responses, _lock=self._shared_lock)
+
+    def clear_conversation(self):
+        self._conversation_history = []
+
+    def get_conversation_history(self):
+        return list(self._conversation_history)
+
+    def set_conversation_history(self, history):
+        self._conversation_history = list(history)
+
+
+class TestResultBuilderAborted:
+    def test_as_aborted_sets_status_and_response(self):
+        prompt = {"sequence": 1, "prompt_name": "test", "prompt": "hi"}
+        result = ResultBuilder(prompt).as_aborted("some trace").build_dict()
+        assert result["status"] == "aborted"
+        assert result["response"] == "-1"
+        assert result["abort_trace"] == "some trace"
+
+    def test_as_aborted_without_trace(self):
+        prompt = {"sequence": 1, "prompt_name": "test", "prompt": "hi"}
+        result = ResultBuilder(prompt).as_aborted().build_dict()
+        assert result["status"] == "aborted"
+        assert result["response"] == "-1"
+        assert result["abort_trace"] is None
+
+    def test_with_abort_triggered(self):
+        prompt = {"sequence": 1, "prompt_name": "test", "prompt": "hi"}
+        result = (
+            ResultBuilder(prompt)
+            .with_response("ok")
+            .with_abort_triggered("trace here")
+            .build_dict()
+        )
+        assert result["status"] == "success"
+        assert result["response"] == "ok"
+        assert result["abort_trace"] == "trace here"
+
+    def test_with_batch_and_aborted(self):
+        prompt = {"sequence": 1, "prompt_name": "test", "prompt": "hi"}
+        result = ResultBuilder(prompt).with_batch(1, "batch_a").as_aborted("abort!").build_dict()
+        assert result["batch_id"] == 1
+        assert result["batch_name"] == "batch_a"
+        assert result["status"] == "aborted"
+        assert result["response"] == "-1"
+
+
+class TestPromptResultAbortedStatus:
+    def test_valid_statuses_includes_aborted(self):
+        assert "aborted" in PromptResult.VALID_STATUSES
+
+    def test_abort_trace_field(self):
+        result = PromptResult(sequence=1, abort_trace="resolved trace")
+        assert result.abort_trace == "resolved trace"
+
+    def test_from_dict_with_abort_trace(self):
+        data = {"sequence": 1, "abort_trace": "test trace", "status": "aborted"}
+        result = PromptResult.from_dict(data)
+        assert result.abort_trace == "test trace"
+        assert result.status == "aborted"
+
+
+class TestEvaluateAbortCondition:
+    def test_no_abort_condition_returns_false(self):
+        prompt = {"sequence": 1, "prompt_name": "p1", "prompt": "hi"}
+        results = {}
+        triggered, trace = _eval_abort(prompt, results)
+        assert triggered is False
+        assert trace is None
+
+    def test_abort_condition_true(self):
+        prompt = {
+            "sequence": 1,
+            "prompt_name": "check",
+            "prompt": "check stuff",
+            "abort_condition": '{{check.status}} == "success"',
+        }
+        results = {"check": {"status": "success", "response": "ok"}}
+        triggered, trace = _eval_abort(prompt, results)
+        assert triggered is True
+        assert trace is not None
+
+    def test_abort_condition_false(self):
+        prompt = {
+            "sequence": 1,
+            "prompt_name": "check",
+            "prompt": "check stuff",
+            "abort_condition": '{{check.status}} == "failed"',
+        }
+        results = {"check": {"status": "success", "response": "ok"}}
+        triggered, trace = _eval_abort(prompt, results)
+        assert triggered is False
+
+    def test_abort_condition_with_json_get(self):
+        prompt = {
+            "sequence": 1,
+            "prompt_name": "check",
+            "prompt": "check stuff",
+            "abort_condition": 'json_get({{check.response}}, "score") < 5',
+        }
+        results = {"check": {"status": "success", "response": '{"score": 2}'}}
+        triggered, trace = _eval_abort(prompt, results)
+        assert triggered is True
+
+
+def _eval_abort(prompt, results_by_name):
+    abort_condition = prompt.get("abort_condition")
+    if not abort_condition or not str(abort_condition).strip():
+        return False, None
+
+    from src.orchestrator.graph import evaluate_condition_with_trace
+
+    should_abort, _, _, abort_trace = evaluate_condition_with_trace(
+        prompt, results_by_name, condition_field="abort_condition"
+    )
+    return should_abort, abort_trace
+
+
+class TestAbortConditionValidation:
+    def test_valid_abort_condition_passes(self):
+        is_valid, error = ConditionEvaluator.validate_syntax('{{check.status}} == "success"')
+        assert is_valid is True
+        assert error is None
+
+    def test_invalid_abort_condition_fails(self):
+        is_valid, error = ConditionEvaluator.validate_syntax("{{check.}} ==")
+        assert is_valid is False
+        assert error is not None
+
+
+class TestAbortInSequentialExecution:
+    def test_sequential_abort_skips_remaining(self, tmp_path):
+        from openpyxl import Workbook
+
+        from src.orchestrator.excel_orchestrator import ExcelOrchestrator
+
+        wb = Workbook()
+
+        ws_config = wb.active
+        ws_config.title = "config"
+        ws_config["A1"] = "field"
+        ws_config["B1"] = "value"
+        ws_config["A2"] = "max_retries"
+        ws_config["B2"] = 1
+
+        ws_prompts = wb.create_sheet(title="prompts")
+        ws_prompts["A1"] = "sequence"
+        ws_prompts["B1"] = "prompt_name"
+        ws_prompts["C1"] = "prompt"
+        ws_prompts["D1"] = "history"
+        ws_prompts["E1"] = "abort_condition"
+
+        ws_prompts["A2"] = 10
+        ws_prompts["B2"] = "check"
+        ws_prompts["C2"] = "Check something"
+        ws_prompts["E2"] = '{{check.response}} == "abort"'
+
+        ws_prompts["A3"] = 20
+        ws_prompts["B3"] = "after_check"
+        ws_prompts["C3"] = "Should be aborted"
+
+        ws_prompts["A4"] = 30
+        ws_prompts["B4"] = "also_aborted"
+        ws_prompts["C4"] = "Also aborted"
+
+        path = str(tmp_path / "abort_seq.xlsx")
+        wb.save(path)
+
+        client = ScriptedClient(responses=["abort"])
+        orchestrator = ExcelOrchestrator(path, client=client, concurrency=1)
+        orchestrator.run()
+
+        results = orchestrator.results
+        assert len(results) == 3
+
+        assert results[0]["prompt_name"] == "check"
+        assert results[0]["status"] == "success"
+        assert results[0]["response"] == "abort"
+        assert results[0]["abort_trace"] is not None
+
+        assert results[1]["status"] == "aborted"
+        assert results[1]["response"] == "-1"
+        assert results[1]["prompt_name"] == "after_check"
+
+        assert results[2]["status"] == "aborted"
+        assert results[2]["response"] == "-1"
+        assert results[2]["prompt_name"] == "also_aborted"
+
+    def test_sequential_no_abort_runs_all(self, tmp_path):
+        from openpyxl import Workbook
+
+        from src.orchestrator.excel_orchestrator import ExcelOrchestrator
+
+        wb = Workbook()
+
+        ws_config = wb.active
+        ws_config.title = "config"
+        ws_config["A1"] = "field"
+        ws_config["B1"] = "value"
+        ws_config["A2"] = "max_retries"
+        ws_config["B2"] = 1
+
+        ws_prompts = wb.create_sheet(title="prompts")
+        ws_prompts["A1"] = "sequence"
+        ws_prompts["B1"] = "prompt_name"
+        ws_prompts["C1"] = "prompt"
+        ws_prompts["D1"] = "history"
+        ws_prompts["E1"] = "abort_condition"
+
+        ws_prompts["A2"] = 10
+        ws_prompts["B2"] = "check"
+        ws_prompts["C2"] = "Check something"
+        ws_prompts["E2"] = '{{check.response}} == "abort"'
+
+        ws_prompts["A3"] = 20
+        ws_prompts["B3"] = "after_check"
+        ws_prompts["C3"] = "Should run normally"
+
+        path = str(tmp_path / "no_abort.xlsx")
+        wb.save(path)
+
+        client = ScriptedClient(responses=["continue"])
+        orchestrator = ExcelOrchestrator(path, client=client, concurrency=1)
+        orchestrator.run()
+
+        results = orchestrator.results
+        assert len(results) == 2
+        assert results[0]["status"] == "success"
+        assert results[0]["abort_trace"] is None
+        assert results[1]["status"] == "success"
+
+
+class TestAbortInBatchExecution:
+    def test_batch_abort_per_row(self, tmp_path):
+        from openpyxl import Workbook
+
+        from src.orchestrator.excel_orchestrator import ExcelOrchestrator
+
+        wb = Workbook()
+
+        ws_config = wb.active
+        ws_config.title = "config"
+        ws_config["A1"] = "field"
+        ws_config["B1"] = "value"
+        ws_config["A2"] = "max_retries"
+        ws_config["B2"] = 1
+
+        ws_prompts = wb.create_sheet(title="prompts")
+        ws_prompts["A1"] = "sequence"
+        ws_prompts["B1"] = "prompt_name"
+        ws_prompts["C1"] = "prompt"
+        ws_prompts["D1"] = "history"
+        ws_prompts["E1"] = "abort_condition"
+
+        ws_prompts["A2"] = 10
+        ws_prompts["B2"] = "check"
+        ws_prompts["C2"] = "Check {{candidate}}"
+        ws_prompts["E2"] = '{{check.response}} == "reject"'
+
+        ws_prompts["A3"] = 20
+        ws_prompts["B3"] = "evaluate"
+        ws_prompts["C3"] = "Evaluate {{candidate}}"
+
+        ws_prompts["A4"] = 30
+        ws_prompts["B4"] = "summarize"
+        ws_prompts["C4"] = "Summarize {{candidate}}"
+
+        ws_data = wb.create_sheet(title="data")
+        ws_data["A1"] = "id"
+        ws_data["B1"] = "batch_name"
+        ws_data["C1"] = "candidate"
+
+        ws_data["A2"] = 1
+        ws_data["B2"] = "alice"
+        ws_data["C2"] = "Alice"
+
+        ws_data["A3"] = 2
+        ws_data["B3"] = "bob"
+        ws_data["C3"] = "Bob"
+
+        path = str(tmp_path / "abort_batch.xlsx")
+        wb.save(path)
+
+        client = ScriptedClient(responses=["reject", "accept"])
+        orchestrator = ExcelOrchestrator(path, client=client, concurrency=1)
+        orchestrator.run()
+
+        results = orchestrator.results
+        assert len(results) == 6
+
+        alice_check = results[0]
+        assert alice_check["batch_name"] == "alice"
+        assert alice_check["status"] == "success"
+        assert alice_check["response"] == "reject"
+        assert alice_check["abort_trace"] is not None
+
+        alice_eval = results[1]
+        assert alice_eval["batch_name"] == "alice"
+        assert alice_eval["status"] == "aborted"
+        assert alice_eval["response"] == "-1"
+
+        alice_summary = results[2]
+        assert alice_summary["batch_name"] == "alice"
+        assert alice_summary["status"] == "aborted"
+
+        bob_check = results[3]
+        assert bob_check["batch_name"] == "bob"
+        assert bob_check["status"] == "success"
+        assert bob_check["response"] == "accept"
+        assert bob_check["abort_trace"] is None
+
+        bob_eval = results[4]
+        assert bob_eval["batch_name"] == "bob"
+        assert bob_eval["status"] == "success"
+
+        bob_summary = results[5]
+        assert bob_summary["batch_name"] == "bob"
+        assert bob_summary["status"] == "success"
+
+    def test_batch_abort_parallel(self, tmp_path):
+        from openpyxl import Workbook
+
+        from src.orchestrator.excel_orchestrator import ExcelOrchestrator
+
+        wb = Workbook()
+
+        ws_config = wb.active
+        ws_config.title = "config"
+        ws_config["A1"] = "field"
+        ws_config["B1"] = "value"
+        ws_config["A2"] = "max_retries"
+        ws_config["B2"] = 1
+
+        ws_prompts = wb.create_sheet(title="prompts")
+        ws_prompts["A1"] = "sequence"
+        ws_prompts["B1"] = "prompt_name"
+        ws_prompts["C1"] = "prompt"
+        ws_prompts["D1"] = "history"
+        ws_prompts["E1"] = "abort_condition"
+
+        ws_prompts["A2"] = 10
+        ws_prompts["B2"] = "check"
+        ws_prompts["C2"] = "Check {{candidate}}"
+        ws_prompts["E2"] = '{{check.response}} == "reject"'
+
+        ws_prompts["A3"] = 20
+        ws_prompts["B3"] = "evaluate"
+        ws_prompts["C3"] = "Evaluate {{candidate}}"
+
+        ws_data = wb.create_sheet(title="data")
+        ws_data["A1"] = "id"
+        ws_data["B1"] = "batch_name"
+        ws_data["C1"] = "candidate"
+
+        ws_data["A2"] = 1
+        ws_data["B2"] = "alice"
+        ws_data["C2"] = "Alice"
+
+        ws_data["A3"] = 2
+        ws_data["B3"] = "bob"
+        ws_data["C3"] = "Bob"
+
+        path = str(tmp_path / "abort_batch_parallel.xlsx")
+        wb.save(path)
+
+        client = ScriptedClient(responses=["reject", "accept"])
+        orchestrator = ExcelOrchestrator(path, client=client, concurrency=2)
+        orchestrator.run()
+
+        results = orchestrator.results
+        results.sort(key=lambda r: (r["batch_id"], r["sequence"]))
+
+        assert len(results) == 4
+
+        alice_results = [r for r in results if r["batch_name"] == "alice"]
+        assert alice_results[0]["status"] == "success"
+        assert alice_results[0]["abort_trace"] is not None
+        assert alice_results[1]["status"] == "aborted"
+
+        bob_results = [r for r in results if r["batch_name"] == "bob"]
+        assert bob_results[0]["status"] == "success"
+        assert bob_results[0].get("abort_trace") is None
+        assert bob_results[1]["status"] == "success"
+
+
+class TestAbortConditionParseFromWorkbook:
+    def test_abort_condition_parsed_from_prompts_sheet(self, tmp_path):
+        from openpyxl import Workbook
+
+        wb = Workbook()
+
+        ws_config = wb.active
+        ws_config.title = "config"
+        ws_config["A1"] = "field"
+        ws_config["B1"] = "value"
+        ws_config["A2"] = "max_retries"
+        ws_config["B2"] = 3
+
+        ws_prompts = wb.create_sheet(title="prompts")
+        ws_prompts["A1"] = "sequence"
+        ws_prompts["B1"] = "prompt_name"
+        ws_prompts["C1"] = "prompt"
+        ws_prompts["D1"] = "history"
+        ws_prompts["E1"] = "abort_condition"
+
+        ws_prompts["A2"] = 10
+        ws_prompts["B2"] = "check"
+        ws_prompts["C2"] = "Check stuff"
+        ws_prompts["E2"] = '{{check.status}} == "failed"'
+
+        ws_prompts["A3"] = 20
+        ws_prompts["B3"] = "no_abort"
+        ws_prompts["C3"] = "No abort condition here"
+
+        path = str(tmp_path / "parse_abort.xlsx")
+        wb.save(path)
+
+        from src.orchestrator.workbook_parser import WorkbookParser
+
+        parser = WorkbookParser(path)
+        prompts = parser.load_prompts()
+
+        assert len(prompts) == 2
+        assert prompts[0]["abort_condition"] == '{{check.status}} == "failed"'
+        assert prompts[1]["abort_condition"] is None
+
+    def test_abort_condition_in_pivot_headers(self):
+        from src.orchestrator.workbook_parser import WorkbookParser
+
+        parser = WorkbookParser.__new__(WorkbookParser)
+        parser._config = MagicMock()
+        parser._config.workbook.sheet_names.config = "config"
+        parser._config.workbook.sheet_names.prompts = "prompts"
+        parser._config.workbook.sheet_names.data = "data"
+        parser._config.workbook.sheet_names.clients = "clients"
+        parser._config.workbook.sheet_names.documents = "documents"
+        parser._config.workbook.sheet_names.tools = "tools"
+        parser._config.workbook.sheet_names.scoring = "scoring"
+        parser._config.workbook.sheet_names.synthesis = "synthesis"
+        parser._config.workbook.defaults = MagicMock()
+        parser._config.workbook.batch = MagicMock()
+        parser._config.workbook.formatting = MagicMock()
+
+        assert "abort_condition" in parser.PROMPTS_HEADERS
+
+
+class TestAbortSummaryCounts:
+    def test_summary_includes_aborted_count(self):
+        from src.orchestrator.results.frame import ResultsFrame
+
+        results = [
+            {
+                "sequence": 1,
+                "prompt_name": "a",
+                "prompt": "x",
+                "status": "success",
+                "response": "ok",
+                "attempts": 1,
+                "abort_trace": None,
+            },
+            {
+                "sequence": 2,
+                "prompt_name": "b",
+                "prompt": "x",
+                "status": "aborted",
+                "response": "-1",
+                "attempts": 0,
+                "abort_trace": "trace",
+            },
+            {
+                "sequence": 3,
+                "prompt_name": "c",
+                "prompt": "x",
+                "status": "aborted",
+                "response": "-1",
+                "attempts": 0,
+                "abort_trace": None,
+            },
+        ]
+        frame = ResultsFrame(results)
+        summary = frame.summary()
+        assert summary["successful"] == 1
+        assert summary["aborted"] == 2
+
+
+class TestAbortConditionWithGraphConditionField:
+    def test_evaluate_condition_field_parameter(self):
+        from src.orchestrator.graph import evaluate_condition_with_trace
+
+        prompt = {
+            "sequence": 1,
+            "prompt_name": "p",
+            "prompt": "hi",
+            "condition": "ignored",
+            "abort_condition": '{{p.status}} == "success"',
+        }
+
+        should_run, _, _, _ = evaluate_condition_with_trace(
+            prompt, {"p": {"status": "success"}}, condition_field="abort_condition"
+        )
+        assert should_run is True
+
+        should_run2, _, _, _ = evaluate_condition_with_trace(
+            prompt, {"p": {"status": "failed"}}, condition_field="abort_condition"
+        )
+        assert should_run2 is False
+
+
+class TestAbortInNonBatchParallel:
+    def test_parallel_abort_skips_remaining(self, tmp_path):
+        from openpyxl import Workbook
+
+        from src.orchestrator.excel_orchestrator import ExcelOrchestrator
+
+        wb = Workbook()
+
+        ws_config = wb.active
+        ws_config.title = "config"
+        ws_config["A1"] = "field"
+        ws_config["B1"] = "value"
+        ws_config["A2"] = "max_retries"
+        ws_config["B2"] = 1
+
+        ws_prompts = wb.create_sheet(title="prompts")
+        ws_prompts["A1"] = "sequence"
+        ws_prompts["B1"] = "prompt_name"
+        ws_prompts["C1"] = "prompt"
+        ws_prompts["D1"] = "history"
+        ws_prompts["E1"] = "abort_condition"
+
+        ws_prompts["A2"] = 10
+        ws_prompts["B2"] = "check"
+        ws_prompts["C2"] = "Check something"
+        ws_prompts["E2"] = '{{check.response}} == "abort"'
+
+        ws_prompts["A3"] = 20
+        ws_prompts["B3"] = "after_check"
+        ws_prompts["C3"] = "Depends on check"
+        ws_prompts["D3"] = '["check"]'
+
+        ws_prompts["A4"] = 30
+        ws_prompts["B4"] = "also_aborted"
+        ws_prompts["C4"] = "Depends on after_check"
+        ws_prompts["D4"] = '["after_check"]'
+
+        path = str(tmp_path / "abort_parallel.xlsx")
+        wb.save(path)
+
+        client = ScriptedClient(responses=["abort", "should not run", "should not run"])
+        orchestrator = ExcelOrchestrator(path, client=client, concurrency=2)
+        orchestrator.run()
+
+        results = orchestrator.results
+        assert len(results) == 3
+
+        results.sort(key=lambda r: r["sequence"])
+
+        assert results[0]["prompt_name"] == "check"
+        assert results[0]["status"] == "success"
+        assert results[0]["abort_trace"] is not None
+
+        assert results[1]["prompt_name"] == "after_check"
+        assert results[1]["status"] == "aborted"
+        assert results[1]["response"] == "-1"
+
+        assert results[2]["prompt_name"] == "also_aborted"
+        assert results[2]["status"] == "aborted"
+        assert results[2]["response"] == "-1"
+
+
+class TestAbortGraphDependencies:
+    def test_abort_condition_creates_dependency_edge(self):
+        from src.orchestrator.graph import build_execution_graph_with_edges
+
+        prompts = [
+            {
+                "sequence": 10,
+                "prompt_name": "gate",
+                "prompt": "Gate check",
+            },
+            {
+                "sequence": 20,
+                "prompt_name": "eval",
+                "prompt": "Evaluate",
+                "abort_condition": '{{gate.status}} == "success"',
+            },
+        ]
+        graph = build_execution_graph_with_edges(prompts)
+
+        assert 10 in graph.nodes[20].dependencies
+
+        abort_edges = [e for e in graph.edges if e.source == "abort_condition"]
+        assert len(abort_edges) == 1
+        assert abort_edges[0].from_seq == 10
+        assert abort_edges[0].to_seq == 20
+
+    def test_abort_condition_does_not_duplicate_edges(self):
+        from src.orchestrator.graph import build_execution_graph_with_edges
+
+        prompts = [
+            {
+                "sequence": 10,
+                "prompt_name": "gate",
+                "prompt": "Gate check",
+            },
+            {
+                "sequence": 20,
+                "prompt_name": "eval",
+                "prompt": "Evaluate",
+                "condition": '{{gate.status}} == "success"',
+                "abort_condition": '{{gate.response}} contains "pass"',
+            },
+        ]
+        graph = build_execution_graph_with_edges(prompts)
+
+        assert 10 in graph.nodes[20].dependencies
+
+        edges_from_10 = [e for e in graph.edges if e.from_seq == 10 and e.to_seq == 20]
+        assert len(edges_from_10) == 2
+        sources = {e.source for e in edges_from_10}
+        assert sources == {"condition", "abort_condition"}

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -89,7 +89,7 @@ class TestLoadPromptTemplate:
 
         result = load_prompt_template("screening_static")
         assert result is not None
-        assert len(result) == 7
+        assert len(result) == 8
         assert result[0].name == "extract_profile"
 
     def test_load_planning_template(self):
@@ -97,7 +97,7 @@ class TestLoadPromptTemplate:
 
         result = load_prompt_template("screening_planning")
         assert result is not None
-        assert len(result) == 4
+        assert len(result) == 5
         names = [p.name for p in result]
         assert "analyze_jd" in names
         assert "refine_criteria" in names
@@ -250,41 +250,41 @@ class TestScreeningFallbackIntegration:
         from sample_workbooks.screening import get_static_screening_prompts
 
         prompts = get_static_screening_prompts()
-        assert len(prompts) == 7
+        assert len(prompts) == 8
         assert prompts[0].name == "extract_profile"
 
     def test_planning_prompts_default(self):
         from sample_workbooks.screening import get_planning_screening_prompts
 
         prompts = get_planning_screening_prompts()
-        assert len(prompts) == 4
+        assert len(prompts) == 5
         assert prompts[0].name == "analyze_jd"
 
     def test_static_prompts_with_valid_template(self):
         from sample_workbooks.screening import get_static_screening_prompts
 
         prompts = get_static_screening_prompts(template_path="screening_static")
-        assert len(prompts) == 7
+        assert len(prompts) == 8
         assert prompts[0].name == "extract_profile"
 
     def test_planning_prompts_with_valid_template(self):
         from sample_workbooks.screening import get_planning_screening_prompts
 
         prompts = get_planning_screening_prompts(template_path="screening_planning")
-        assert len(prompts) == 4
+        assert len(prompts) == 5
         assert prompts[0].name == "analyze_jd"
 
     def test_static_prompts_fallback_on_missing_template(self):
         from sample_workbooks.screening import get_static_screening_prompts
 
         prompts = get_static_screening_prompts(template_path="nonexistent_xyz")
-        assert len(prompts) == 7
+        assert len(prompts) == 8
 
     def test_planning_prompts_fallback_on_missing_template(self):
         from sample_workbooks.screening import get_planning_screening_prompts
 
         prompts = get_planning_screening_prompts(template_path="nonexistent_xyz")
-        assert len(prompts) == 4
+        assert len(prompts) == 5
 
     def test_synthesis_prompts_default(self):
         from sample_workbooks.screening import get_screening_synthesis_prompts
@@ -342,7 +342,7 @@ class TestScreeningSkillsPlanningTemplate:
 
         result = load_prompt_template("screening_skills_planning")
         assert result is not None
-        assert len(result) == 4
+        assert len(result) == 5
 
     def test_skills_planning_has_correct_prompt_names(self):
         from src.prompt_templates import load_prompt_template
@@ -352,7 +352,17 @@ class TestScreeningSkillsPlanningTemplate:
         assert "analyze_jd" in names
         assert "refine_criteria" in names
         assert "extract_profile" in names
+        assert "gate_evaluation" in names
         assert "overall_assessment" in names
+
+    def test_skills_planning_gate_has_abort_condition(self):
+        from src.prompt_templates import load_prompt_template
+
+        result = load_prompt_template("screening_skills_planning")
+        gate = next(p for p in result if p.name == "gate_evaluation")
+        assert gate.abort_condition is not None
+        assert "json_get" in gate.abort_condition
+        assert "proceed" in gate.abort_condition
 
     def test_skills_planning_analyze_jd_is_generator(self):
         from src.prompt_templates import load_prompt_template
@@ -405,7 +415,7 @@ class TestScreeningSkillsPlanningTemplate:
         from sample_workbooks.screening import get_planning_screening_prompts
 
         prompts = get_planning_screening_prompts(template_path="screening_skills_planning")
-        assert len(prompts) == 4
+        assert len(prompts) == 5
         names = [p.name for p in prompts]
         assert "analyze_jd" in names
         assert "refine_criteria" in names

--- a/tests/test_results_frame.py
+++ b/tests/test_results_frame.py
@@ -414,6 +414,74 @@ class TestResultsFrameScoresPivot:
         assert "skills_match" in names
         assert "raw_years" not in names
 
+    def test_pivot_includes_aborted_batches_with_sentinel_scores(self):
+        from src.orchestrator.results import ResultsFrame
+
+        results = [
+            _make_result(
+                batch_id=1,
+                batch_name="alice",
+                scores={"skills": 8.0, "education": 7.0},
+                composite_score=7.5,
+            ),
+            _make_result(
+                batch_id=2,
+                batch_name="bob",
+                sequence=2,
+                scores={"skills": 5.0, "education": 6.0},
+                composite_score=5.5,
+            ),
+            _make_result(
+                batch_id=3,
+                batch_name="rejected",
+                sequence=10,
+                prompt_name="extract_profile",
+                status="success",
+                scores={},
+                composite_score=None,
+                scoring_status="skipped",
+            ),
+            _make_result(
+                batch_id=3,
+                batch_name="rejected",
+                sequence=12,
+                prompt_name="eval_skills",
+                status="aborted",
+                scores={},
+                composite_score=None,
+                scoring_status="skipped",
+                response="-1",
+            ),
+        ]
+
+        criteria = self._criteria(
+            [("skills", "normalized_score"), ("education", "normalized_score")]
+        )
+        frame = ResultsFrame(results)
+        pivot = frame.scores_pivot(criteria)
+
+        batch_names = pivot["batch_name"].unique().to_list()
+        assert "alice" in batch_names
+        assert "bob" in batch_names
+        assert "rejected" in batch_names
+
+        rejected = pivot.filter(
+            (pl.col("batch_name") == "rejected") & (pl.col("criteria_name") != "_composite")
+        )
+        assert rejected.height == 2
+
+        skills_row = rejected.filter(pl.col("criteria_name") == "skills")
+        assert skills_row["normalized_score"].item() == -1
+        assert skills_row["weighted_score"].item() is None
+
+        edu_row = rejected.filter(pl.col("criteria_name") == "education")
+        assert edu_row["normalized_score"].item() == -1
+        assert edu_row["weighted_score"].item() is None
+
+        composites = pivot.filter(pl.col("criteria_name") == "_composite")
+        rejected_composite = composites.filter(pl.col("batch_name") == "rejected")
+        assert rejected_composite["weighted_score"].item() == -1
+
 
 class TestResultsFrameCompositePipeline:
     """Tests for composite score computation via Polars pipeline."""


### PR DESCRIPTION
## Summary

- **Abort condition support**: Wire `abort_condition` field through PromptSpec, YAML loader, and workbook headers, enabling early termination of remaining prompts for a batch row when a condition evaluates true
- **Gate evaluation prompt**: Add a `gate_evaluation` prompt with `abort_condition` to all three screening templates (static, planning, skills-based) that screens out clearly unqualified candidates before expensive per-skill LLM evaluations
- **Structured log context**: Annotate all orchestrator log lines with `batch_name` and `prompt_name` using `ContextVar`-based context, so downstream logs from FFAI, clients, and prompt_builder automatically inherit the current execution context
- **Logging improvements**: Demote full prompt logging to DEBUG level with truncated INFO summaries to reduce log noise

## Changes

### Abort condition & gate evaluation (e79f9ff)
- Add `abort_condition` field to `PromptSpec`, YAML template loader, and workbook headers
- Add `gate_evaluation` prompt to `screening_static.yaml`, `screening_planning.yaml`, `screening_skills_planning.yaml`, and Python hardcoded fallbacks
- Fix `scoring.py` to treat `"aborted"` status same as `"skipped"` in `extract_scores`
- Fix `scores_pivot()` to include aborted batches with sentinel values (`normalized_score: -1`, `composite: -1`)
- Show aborted count in orchestrator summary output

### Structured log context (efe0b44)
- Add `src/observability/log_context.py` with `ContextVar`s, `log_context()` context manager, `LogContextFilter`, and `ContextFormatter`
- Wrap `_execute_with_retry`, planning runner, and synthesis runner with `log_context()`
- Update log format: `batch=%(batch_name)s prompt=%(prompt_name)s - %(message)s`

### Logging improvements (a4347bd)
- Demote full prompt text and resolved prompt logging to DEBUG
- Add truncated INFO summaries (first 80 chars)

## Test plan

- [x] All 1848 tests pass
- [x] Ruff lint clean
- [x] End-to-end manifest screening run with 7 resumes — 4 candidates passed gate, 3 aborted (30 prompts saved)
- [x] Log output verified: batch_name/prompt_name correctly annotated in batch, planning, and synthesis phases