### PR TITLE
feat: add BM25 hard-exclusion pre-screening pipeline for resume ranking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -884,7 +884,7 @@ orchestrator.run()
 
 ### Pre-Screening (Cost Reduction)
 
-Embedding-based resume ranking filters candidates before the expensive LLM pipeline. Two-tier scoring: BM25 keyword matching on extracted named entities, then dense embedding cosine similarity. Combined with configurable weights (default 30/70 BM25/embedding).
+Embedding-based resume ranking filters candidates before the expensive LLM pipeline. Two-tier pipeline: Tier 1 is a **hard exclusion** gate using BM25 keyword matching — candidates below threshold are removed entirely. Tier 2 uses dense embedding cosine similarity to rank survivors, with scores combined using configurable weights (default 30/70 BM25/embedding).
 
 ```bash
 # Pre-screen top 20 resumes before LLM evaluation
@@ -892,9 +892,6 @@ python scripts/create_screening_manifest.py ./resumes/ --jd ./jd.md --pre-screen
 
 # Pre-screen top 10 with planning mode
 python scripts/create_screening_manifest.py ./resumes/ --jd ./jd.md --pre-screen 10 --planning
-
-# Use default top_k from config (20)
-python scripts/create_screening_manifest.py ./resumes/ --jd ./jd.md --pre-screen
 
 # Shell script with pre-screening
 ./convenience/screening_manifest.sh --pre-screen 10 small
@@ -904,14 +901,13 @@ python scripts/create_screening_manifest.py ./resumes/ --jd ./jd.md --pre-screen
 
 ```yaml
 pre_screening:
-  top_k: 20
+  enabled: true
   embedding_model: "mistral/mistral-embed"
   bm25_weight: 0.3
   embedding_weight: 0.7
-  min_entity_overlap: 0
-  max_text_length: 8000
-  embedding_batch_size: 20
-  embedding_cache_size: 1000
+  bm25_min_score: 0.0
+  bm25_min_overlap_ratio: 0.05
+  embedding_cache_size: 512
 ```
 
 **Outputs:** `data.yaml` (top-K batch rows), `documents.yaml` (top-K document refs), `pre_screening_report.yaml` (full ranking with scores).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ src/
 │   ├── document_registry.py   # Document reference management
 │   ├── document_processor.py  # Document loading and caching
 │   ├── discovery.py           # Auto-discovery of documents for evaluation
+│   ├── pre_screener.py        # Embedding-based resume pre-screening and ranking
 │   ├── planning.py            # Planning phase artifact parsing and validation
 │   ├── planning_runner.py     # Planning phase execution and injection
 │   ├── scoring.py             # Scoring rubric extraction and aggregation
@@ -220,6 +221,7 @@ tests/
 ├── test_planning_artifact_parser.py  # Planning artifact parser unit tests
 ├── test_synthesis.py          # Cross-row synthesis tests
 ├── test_discovery.py          # Auto-discovery utility tests
+├── test_pre_screener.py       # Pre-screening ranking tests
 ├── test_rag.py                # RAG client tests
 ├── test_rag_chunkers.py       # Chunking strategy tests
 ├── test_rag_search.py         # Search strategy tests
@@ -880,6 +882,40 @@ orchestrator = ManifestOrchestrator(
 orchestrator.run()
 ```
 
+### Pre-Screening (Cost Reduction)
+
+Embedding-based resume ranking filters candidates before the expensive LLM pipeline. Two-tier scoring: BM25 keyword matching on extracted named entities, then dense embedding cosine similarity. Combined with configurable weights (default 30/70 BM25/embedding).
+
+```bash
+# Pre-screen top 20 resumes before LLM evaluation
+python scripts/create_screening_manifest.py ./resumes/ --jd ./jd.md --pre-screen 20
+
+# Pre-screen top 10 with planning mode
+python scripts/create_screening_manifest.py ./resumes/ --jd ./jd.md --pre-screen 10 --planning
+
+# Use default top_k from config (20)
+python scripts/create_screening_manifest.py ./resumes/ --jd ./jd.md --pre-screen
+
+# Shell script with pre-screening
+./convenience/screening_manifest.sh --pre-screen 10 small
+```
+
+**Configuration (`config/main.yaml`):**
+
+```yaml
+pre_screening:
+  top_k: 20
+  embedding_model: "mistral/mistral-embed"
+  bm25_weight: 0.3
+  embedding_weight: 0.7
+  min_entity_overlap: 0
+  max_text_length: 8000
+  embedding_batch_size: 20
+  embedding_cache_size: 1000
+```
+
+**Outputs:** `data.yaml` (top-K batch rows), `documents.yaml` (top-K document refs), `pre_screening_report.yaml` (full ranking with scores).
+
 ## Manifest Workflow
 
 **For comprehensive manifest documentation, see [MANIFEST_README.md](./MANIFEST_README.md)**
@@ -1190,7 +1226,7 @@ Add false positives to `vulture_whitelist.py` with a `# noqa: V103` comment expl
 
 ### config/main.yaml
 
-Core application settings: workbook sheet names, orchestrator settings, document processor config, RAG settings.
+Core application settings: workbook sheet names, orchestrator settings, document processor config, RAG settings, pre-screening config.
 
 ### config/paths.yaml
 

--- a/MANIFEST_README.md
+++ b/MANIFEST_README.md
@@ -992,9 +992,11 @@ manifest can screen different resume folders against different job descriptions.
 
 ### Pre-Screening
 
-Use `--pre-screen [N]` to filter resumes via embedding similarity before
-creating the manifest. Only the top-K candidates are baked into `data.yaml`
-and `documents.yaml`, reducing LLM costs for large resume folders.
+Use `--pre-screen N` (required integer) to filter resumes before creating
+the manifest. A two-tier pipeline first excludes candidates via BM25 hard
+gating, then ranks survivors via embedding similarity. Only the top-N
+candidates are baked into `data.yaml` and `documents.yaml`, reducing LLM
+costs for large resume folders.
 
 ```bash
 # Pre-screen top 20 resumes before creating manifest

--- a/MANIFEST_README.md
+++ b/MANIFEST_README.md
@@ -990,6 +990,30 @@ The manifest is created without `data.yaml` or `documents.yaml` — those are
 injected at runtime via `--resumes-path` and `--jd`. This means the same
 manifest can screen different resume folders against different job descriptions.
 
+### Pre-Screening
+
+Use `--pre-screen [N]` to filter resumes via embedding similarity before
+creating the manifest. Only the top-K candidates are baked into `data.yaml`
+and `documents.yaml`, reducing LLM costs for large resume folders.
+
+```bash
+# Pre-screen top 20 resumes before creating manifest
+python scripts/create_screening_manifest.py ./manifests/manifest_screening \
+    --resumes-path ./resumes/ --jd ./jd.md --pre-screen 20
+
+# Pre-screen with planning mode
+python scripts/create_screening_manifest.py ./manifests/manifest_screening \
+    --resumes-path ./resumes/ --jd ./jd.md --planning --pre-screen 10
+```
+
+This produces `data.yaml`, `documents.yaml` (with filtered subset), and
+`pre_screening_report.yaml` (full ranking for all candidates). Since
+candidates are baked in, run without `--documents-path`:
+
+```bash
+python scripts/manifest_run.py ./manifests/manifest_screening -c 5
+```
+
 For full documentation, see [USE_CASES/resume_screening.md](../USE_CASES/resume_screening.md).
 
 ---
@@ -1422,6 +1446,9 @@ python scripts/manifest_export.py ./workbook.xlsx
 
 # Create screening manifest from folder (YAML-only, no baked data)
 python scripts/create_screening_manifest.py --resumes-path ./resumes/ --jd ./jd.md
+
+# Create screening manifest with pre-screening (top-20 baked in)
+python scripts/create_screening_manifest.py --resumes-path ./resumes/ --jd ./jd.md --pre-screen 20
 
 # Run manifest (outputs to ./outputs/<manifest_name>/<timestamp>.parquet)
 python scripts/manifest_run.py ./manifests/manifest_name/ -c 4

--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,7 @@ observability:
 - Want document Q&A with semantic search
 - Need prompts that can call tools (search, calculate, fetch) at runtime
 - Want to screen resumes against a job description with AI scoring
+- Need embedding-based pre-screening to reduce LLM evaluation costs
 
 ### Consider alternatives if you need:
 

--- a/USE_CASES/resume_screening.md
+++ b/USE_CASES/resume_screening.md
@@ -78,14 +78,15 @@ the synthesis `top_n` count. Resumes are always injected at runtime.
 
 ### Pre-Screening (Cost Reduction)
 
-Both creation scripts accept `--pre-screen [N]` to filter resumes via
-embedding similarity before baking them into the workbook or manifest.
-This reduces LLM costs by only evaluating the top-K candidates instead
-of the full folder.
+Both creation scripts accept `--pre-screen N` (required integer) to filter
+resumes before baking them into the workbook or manifest. This reduces LLM
+costs by only evaluating the top-N candidates instead of the full folder.
 
-Two-tier scoring: BM25 keyword matching on extracted named entities,
-then dense embedding cosine similarity. Combined with configurable
-weights (default 30/70 BM25/embedding).
+Two-tier pipeline: Tier 1 is a **hard exclusion** gate using BM25 keyword
+matching on extracted named entities — candidates below the minimum score or
+overlap threshold are removed entirely. Tier 2 uses dense embedding cosine
+similarity to rank survivors, with BM25 and embedding scores combined using
+configurable weights (default 30/70 BM25/embedding).
 
 ```bash
 # Workbook: pre-screen top 20, bake filtered set into .xlsx
@@ -95,10 +96,6 @@ python scripts/create_screening_workbook.py ./screening.xlsx \
 # Manifest: pre-screen top 10, bake filtered set into data.yaml
 python scripts/create_screening_manifest.py ./manifests/manifest_screening \
     --resumes-path ./resumes/ --jd ./jd.md --planning --pre-screen 10
-
-# Use config default top_k (20)
-python scripts/create_screening_manifest.py ./manifests/manifest_screening \
-    --resumes-path ./resumes/ --jd ./jd.md --pre-screen
 ```
 
 Pre-screening is a **creation-time** filter — it runs before the workbook
@@ -115,11 +112,10 @@ filtering by curating the folder contents before running.
 pre_screening:
   enabled: true
   embedding_model: "mistral/mistral-embed"
-  top_k: 20
   bm25_weight: 0.3
   embedding_weight: 0.7
   bm25_min_score: 0.0
-  bm25_min_overlap_ratio: 0.0
+  bm25_min_overlap_ratio: 0.05
   embedding_cache_size: 512
 ```
 
@@ -413,7 +409,7 @@ python scripts/create_screening_workbook.py <output_path> [options]
 | `--client` | No | config default | Client type from `config/clients.yaml` |
 | `--system-instructions` | No | recruiter prompt | System instructions for AI |
 | `--evaluation-strategy` | No | `balanced` | Scoring strategy name |
-| `--pre-screen` | No | — | Pre-screen top-N resumes via embeddings (baked in) |
+| `--pre-screen` | No | — | Pre-screen top-N resumes via embeddings (N required, e.g. `--pre-screen 10`) |
 | `--verbose` | No | off | Enable verbose output |
 
 **Examples:**
@@ -466,7 +462,7 @@ python scripts/create_screening_manifest.py [output_dir] [options]
 | `--client` | No | config default | Client type from `config/clients.yaml` |
 | `--system-instructions` | No | recruiter prompt | System instructions for AI |
 | `--evaluation-strategy` | No | `balanced` | Scoring strategy name |
-| `--pre-screen` | No | — | Pre-screen top-N resumes via embeddings (bakes into `data.yaml`) |
+| `--pre-screen` | No | — | Pre-screen top-N resumes via embeddings (N required, bakes into `data.yaml`) |
 | `--verbose` | No | off | Enable verbose output |
 
 **Examples:**
@@ -753,10 +749,11 @@ resumes/               job_descriptions/
         │                      │  tags="shared"
         │                      │
         v                      v
-   [--pre-screen?]          Shared doc
+   [--pre-screen N]          Shared doc
    ResumePreScreener       (available to all
    .rank_resumes()          prompts, not bound
-   .filter_to_top_k()       to any data row)
+   → (ranked, excluded)     to any data row)
+   .filter_to_top_k()
         │                         │
         v                         │
    create_data_rows_              │
@@ -781,10 +778,11 @@ resumes/               job_descriptions/
 
 Key points:
 
-- `--pre-screen [N]` filters discovered resumes via BM25 + embedding
-  similarity before creating batch data. Only the top-K candidates
-  proceed to LLM evaluation. This is a creation-time filter on
-  `create_screening_workbook.py` and `create_screening_manifest.py`.
+- `--pre-screen N` (N required) filters discovered resumes via a two-tier
+  pipeline: BM25 hard exclusion (removes candidates below threshold), then
+  embedding similarity ranking of survivors. Only the top-N proceed to LLM
+  evaluation. This is a creation-time filter on `create_screening_workbook.py`
+  and `create_screening_manifest.py`.
 - `--shared-document` creates a document with a `reference_name` derived
   from the filename (e.g., `senior_engineer.md` → `senior_engineer`).
   Use `--shared-document-name` to override (e.g., `--shared-document-name

--- a/USE_CASES/resume_screening.md
+++ b/USE_CASES/resume_screening.md
@@ -17,6 +17,9 @@ inv screening.run --resumes-path ./resumes/ --jd ./jd.md
 #    Or create a manifest and run it (no Excel intermediary)
 inv screening.manifest --resumes-path ./resumes/ --jd ./jd.md
 
+#    Pre-screen top 20 resumes before expensive LLM evaluation
+inv screening.manifest --resumes-path ./resumes/ --jd ./jd.md --pre-screen 20
+
 # 3. Results are written into the workbook (Excel) or parquet (Manifest)
 ```
 
@@ -72,6 +75,57 @@ giving you control over what gets baked in vs injected at runtime.
 
 `--resumes-path` on the manifest script is optional and used only for sizing
 the synthesis `top_n` count. Resumes are always injected at runtime.
+
+### Pre-Screening (Cost Reduction)
+
+Both creation scripts accept `--pre-screen [N]` to filter resumes via
+embedding similarity before baking them into the workbook or manifest.
+This reduces LLM costs by only evaluating the top-K candidates instead
+of the full folder.
+
+Two-tier scoring: BM25 keyword matching on extracted named entities,
+then dense embedding cosine similarity. Combined with configurable
+weights (default 30/70 BM25/embedding).
+
+```bash
+# Workbook: pre-screen top 20, bake filtered set into .xlsx
+python scripts/create_screening_workbook.py ./screening.xlsx \
+    --resumes-path ./resumes/ --jd ./jd.md --planning --pre-screen 20
+
+# Manifest: pre-screen top 10, bake filtered set into data.yaml
+python scripts/create_screening_manifest.py ./manifests/manifest_screening \
+    --resumes-path ./resumes/ --jd ./jd.md --planning --pre-screen 10
+
+# Use config default top_k (20)
+python scripts/create_screening_manifest.py ./manifests/manifest_screening \
+    --resumes-path ./resumes/ --jd ./jd.md --pre-screen
+```
+
+Pre-screening is a **creation-time** filter — it runs before the workbook
+or manifest is created. The `run_orchestrator.py` and `manifest_run.py`
+scripts do not need (or accept) `--pre-screen`; they simply execute
+whatever candidates are in the artifact.
+
+For runtime injection modes (templates without baked-in resumes), control
+filtering by curating the folder contents before running.
+
+**Configuration (`config/main.yaml`):**
+
+```yaml
+pre_screening:
+  enabled: true
+  embedding_model: "mistral/mistral-embed"
+  top_k: 20
+  bm25_weight: 0.3
+  embedding_weight: 0.7
+  bm25_min_score: 0.0
+  bm25_min_overlap_ratio: 0.0
+  embedding_cache_size: 512
+```
+
+**Outputs:** In addition to the workbook or manifest files, a
+`pre_screening_report.yaml` is written alongside the artifact containing
+the full ranking with scores for all candidates (not just the top-K).
 
 ---
 
@@ -359,6 +413,7 @@ python scripts/create_screening_workbook.py <output_path> [options]
 | `--client` | No | config default | Client type from `config/clients.yaml` |
 | `--system-instructions` | No | recruiter prompt | System instructions for AI |
 | `--evaluation-strategy` | No | `balanced` | Scoring strategy name |
+| `--pre-screen` | No | — | Pre-screen top-N resumes via embeddings (baked in) |
 | `--verbose` | No | off | Enable verbose output |
 
 **Examples:**
@@ -380,6 +435,10 @@ python scripts/create_screening_workbook.py ./screening.xlsx \
 # Template with JD baked in (resumes injected at runtime)
 python scripts/create_screening_workbook.py ./template.xlsx \
     --jd ./jd.md
+
+# Pre-screen top 10 resumes before baking in
+python scripts/create_screening_workbook.py ./screening.xlsx \
+    --resumes-path ./resumes/ --jd ./jd.md --pre-screen 10
 
 # Generic template (nothing baked in)
 python scripts/create_screening_workbook.py ./template.xlsx
@@ -407,6 +466,7 @@ python scripts/create_screening_manifest.py [output_dir] [options]
 | `--client` | No | config default | Client type from `config/clients.yaml` |
 | `--system-instructions` | No | recruiter prompt | System instructions for AI |
 | `--evaluation-strategy` | No | `balanced` | Scoring strategy name |
+| `--pre-screen` | No | — | Pre-screen top-N resumes via embeddings (bakes into `data.yaml`) |
 | `--verbose` | No | off | Enable verbose output |
 
 **Examples:**
@@ -426,6 +486,10 @@ python scripts/create_screening_manifest.py ./manifests/my_screening \
 # Skills-based planning (per-skill decomposition)
 python scripts/create_screening_manifest.py ./manifests/my_screening \
     --jd ./jd.md --planning --planning-prompts screening_skills_planning
+
+# Pre-screen top 20 resumes before creating manifest
+python scripts/create_screening_manifest.py ./manifests/my_screening \
+    --resumes-path ./resumes/ --jd ./jd.md --pre-screen 20
 ```
 
 ### `run_orchestrator.py` (with discovery flags)
@@ -517,6 +581,9 @@ inv screening.run --resumes-path ./resumes/ --jd ./jd.md --planning
 
 # Create + run with planning phase (Manifest)
 inv screening.manifest --resumes-path ./resumes/ --jd ./jd.md --planning
+
+# Pre-screen top 20 resumes before LLM evaluation
+inv screening.manifest --resumes-path ./resumes/ --jd ./jd.md --pre-screen 20
 
 # Just create (don't run)
 inv screening.create --resumes-path ./resumes/ --jd ./jd.md --output ./my_screen.xlsx
@@ -679,35 +746,45 @@ resumes/               job_descriptions/
         v                      v
    discover_documents()   _resolve_shared_document()
         │                      │
-        │  reference_name      │  reference_name (derived
-        │  common_name         │    from filename stem,
-        │  file_path           │    e.g. "senior_engineer")
+        │                      │  reference_name (derived
+        │                      │    from filename stem,
+        │                      │    e.g. "senior_engineer")
         │                      │  file_path (absolute)
         │                      │  tags="shared"
         │                      │
         v                      v
-   create_data_rows_        Shared doc
-   from_documents()         (available to all
-   (one row per resume       prompts, not bound
-    with _documents          to any data row)
-    column binding)                │
-        │                          │
-         v                          v
-    ┌──────────────────────────────────────────────────────┐
-    │  OrchestratorBase._inject_discovery_overrides()       │
-    │                                                        │
-    │  1. Load workbook sheets OR manifest YAML files        │
-    │  2. If documents_path: discover & inject docs + data   │
-    │  3. If shared_document_path: inject as shared doc      │
-    │  4. Merge with any source docs                        │
-    │  5. Run validation + execution                        │
-    └──────────────────────────────────────────────────────┘
+   [--pre-screen?]          Shared doc
+   ResumePreScreener       (available to all
+   .rank_resumes()          prompts, not bound
+   .filter_to_top_k()       to any data row)
+        │                         │
+        v                         │
+   create_data_rows_              │
+   from_documents()               │
+   (one row per resume            │
+    with _documents               │
+    column binding)               │
+        │                         │
+        v                         v
+   ┌──────────────────────────────────────────────────────┐
+   │  OrchestratorBase._inject_discovery_overrides()       │
+   │                                                        │
+   │  1. Load workbook sheets OR manifest YAML files        │
+   │  2. If documents_path: discover & inject docs + data   │
+   │  3. If shared_document_path: inject as shared doc      │
+   │  4. Merge with any source docs                        │
+   │  5. Run validation + execution                        │
+   └──────────────────────────────────────────────────────┘
 
-    Shared by both ExcelOrchestrator and ManifestOrchestrator.
+   Shared by both ExcelOrchestrator and ManifestOrchestrator.
 ```
 
 Key points:
 
+- `--pre-screen [N]` filters discovered resumes via BM25 + embedding
+  similarity before creating batch data. Only the top-K candidates
+  proceed to LLM evaluation. This is a creation-time filter on
+  `create_screening_workbook.py` and `create_screening_manifest.py`.
 - `--shared-document` creates a document with a `reference_name` derived
   from the filename (e.g., `senior_engineer.md` → `senior_engineer`).
   Use `--shared-document-name` to override (e.g., `--shared-document-name

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -270,7 +270,6 @@ observability:
 pre_screening:
   enabled: true
   embedding_model: "mistral/mistral-embed"
-  top_k: 20
   bm25_weight: 0.3
   embedding_weight: 0.7
   bm25_min_score: 0.0

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -266,3 +266,13 @@ observability:
     insecure: true
   token_tracking: true
   cost_tracking: true
+
+pre_screening:
+  enabled: true
+  embedding_model: "mistral/mistral-embed"
+  top_k: 20
+  bm25_weight: 0.3
+  embedding_weight: 0.7
+  bm25_min_score: 0.0
+  bm25_min_overlap_ratio: 0.0
+  embedding_cache_size: 512

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -274,5 +274,5 @@ pre_screening:
   bm25_weight: 0.3
   embedding_weight: 0.7
   bm25_min_score: 0.0
-  bm25_min_overlap_ratio: 0.0
+  bm25_min_overlap_ratio: 0.05
   embedding_cache_size: 512

--- a/convenience/screening.sh
+++ b/convenience/screening.sh
@@ -1,16 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SIZE="${1:-}"
-case "$SIZE" in
-  small)  RESUMES="./library/resumes_small/" ;;
-  medium) RESUMES="./library/resumes_medium/" ;;
-  "")     RESUMES="./library/resumes/" ;;
-  *)
-    echo "Usage: $0 [small|medium]"
-    echo "  (no argument = full resume set)"
-    exit 1
-    ;;
-esac
+RESUMES="./library/resumes/"
+PRESCREEN_FLAG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    small|medium)
+      if [ "$1" = "small" ]; then RESUMES="./library/resumes_small/"; fi
+      if [ "$1" = "medium" ]; then RESUMES="./library/resumes_medium/"; fi
+      shift
+      ;;
+    --pre-screen)
+      PRESCREEN_FLAG="--pre-screen"
+      shift
+      if [[ $# -gt 0 ]] && [[ ! "$1" =~ ^- ]]; then
+        PRESCREEN_FLAG="--pre-screen $1"
+        shift
+      fi
+      ;;
+    *)
+      echo "Usage: $0 [small|medium] [--pre-screen [N]]"
+      echo ""
+      echo "Resume set:"
+      echo "  (no argument)      Full set (library/resumes/)"
+      echo "  small              Small set (library/resumes_small/)"
+      echo "  medium             Medium set (library/resumes_medium/)"
+      echo ""
+      echo "Pre-screening:"
+      echo "  --pre-screen       Enable pre-screening with config default (20)"
+      echo "  --pre-screen 10    Enable pre-screening with custom top-K"
+      exit 1
+      ;;
+  esac
+done
+
 WORKBOOK="screening_$(date +%Y%m%d%H%M%S).xlsx"
 python scripts/create_screening_workbook.py "./$WORKBOOK" \
   --jd ./library/job_descriptions/Sample_JD_Google_Data_Engineer.md \
@@ -18,5 +41,7 @@ python scripts/create_screening_workbook.py "./$WORKBOOK" \
   --planning \
   --planning-client litellm-mistral-large \
   --planning-prompts screening_skills_planning \
-  --synthesis-prompts screening_synthesis
+  --synthesis-prompts screening_synthesis \
+  $PRESCREEN_FLAG
+
 python scripts/run_orchestrator.py "./$WORKBOOK" -c 5

--- a/convenience/screening.sh
+++ b/convenience/screening.sh
@@ -11,11 +11,13 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --pre-screen)
-      PRESCREEN_FLAG="--pre-screen"
       shift
       if [[ $# -gt 0 ]] && [[ ! "$1" =~ ^- ]]; then
         PRESCREEN_FLAG="--pre-screen $1"
         shift
+      else
+        echo "Error: --pre-screen requires a number (e.g., --pre-screen 10)"
+        exit 1
       fi
       ;;
     *)
@@ -27,8 +29,7 @@ while [[ $# -gt 0 ]]; do
       echo "  medium             Medium set (library/resumes_medium/)"
       echo ""
       echo "Pre-screening:"
-      echo "  --pre-screen       Enable pre-screening with config default (20)"
-      echo "  --pre-screen 10    Enable pre-screening with custom top-K"
+      echo "  --pre-screen 10    Enable pre-screening with top-K candidates"
       exit 1
       ;;
   esac

--- a/convenience/screening_manifest.sh
+++ b/convenience/screening_manifest.sh
@@ -1,16 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SIZE="${1:-}"
-case "$SIZE" in
-  small)  RESUMES="./library/resumes_small/" ;;
-  medium) RESUMES="./library/resumes_medium/" ;;
-  "")     RESUMES="./library/resumes/" ;;
-  *)
-    echo "Usage: $0 [small|medium]"
-    echo "  (no argument = full resume set)"
-    exit 1
-    ;;
-esac
+RESUMES="./library/resumes/"
+PRESCREEN_FLAG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    small|medium)
+      if [ "$1" = "small" ]; then RESUMES="./library/resumes_small/"; fi
+      if [ "$1" = "medium" ]; then RESUMES="./library/resumes_medium/"; fi
+      shift
+      ;;
+    --pre-screen)
+      PRESCREEN_FLAG="--pre-screen"
+      shift
+      if [[ $# -gt 0 ]] && [[ ! "$1" =~ ^- ]]; then
+        PRESCREEN_FLAG="--pre-screen $1"
+        shift
+      fi
+      ;;
+    *)
+      echo "Usage: $0 [small|medium] [--pre-screen [N]]"
+      echo ""
+      echo "Resume set:"
+      echo "  (no argument)      Full set (library/resumes/)"
+      echo "  small              Small set (library/resumes_small/)"
+      echo "  medium             Medium set (library/resumes_medium/)"
+      echo ""
+      echo "Pre-screening:"
+      echo "  --pre-screen       Enable pre-screening with config default (20)"
+      echo "  --pre-screen 10    Enable pre-screening with custom top-K"
+      exit 1
+      ;;
+  esac
+done
+
 MANIFEST_DIR="./manifests/manifest_screening_skills_$(date +%Y%m%d%H%M%S)"
 python scripts/create_screening_manifest.py "$MANIFEST_DIR" \
   --jd ./library/job_descriptions/Sample_JD_Google_Data_Engineer.md \
@@ -18,6 +41,12 @@ python scripts/create_screening_manifest.py "$MANIFEST_DIR" \
   --planning \
   --planning-client litellm-mistral-large \
   --planning-prompts screening_skills_planning \
-  --synthesis-prompts screening_synthesis
-python scripts/manifest_run.py "$MANIFEST_DIR" \
-  --documents-path "$RESUMES" -c 5
+  --synthesis-prompts screening_synthesis \
+  $PRESCREEN_FLAG
+
+if [ -n "$PRESCREEN_FLAG" ]; then
+  python scripts/manifest_run.py "$MANIFEST_DIR" -c 5
+else
+  python scripts/manifest_run.py "$MANIFEST_DIR" \
+    --documents-path "$RESUMES" -c 5
+fi

--- a/convenience/screening_manifest.sh
+++ b/convenience/screening_manifest.sh
@@ -11,11 +11,13 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --pre-screen)
-      PRESCREEN_FLAG="--pre-screen"
       shift
       if [[ $# -gt 0 ]] && [[ ! "$1" =~ ^- ]]; then
         PRESCREEN_FLAG="--pre-screen $1"
         shift
+      else
+        echo "Error: --pre-screen requires a number (e.g., --pre-screen 10)"
+        exit 1
       fi
       ;;
     *)
@@ -27,8 +29,7 @@ while [[ $# -gt 0 ]]; do
       echo "  medium             Medium set (library/resumes_medium/)"
       echo ""
       echo "Pre-screening:"
-      echo "  --pre-screen       Enable pre-screening with config default (20)"
-      echo "  --pre-screen 10    Enable pre-screening with custom top-K"
+      echo "  --pre-screen 10    Enable pre-screening with top-K candidates"
       exit 1
       ;;
   esac

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -381,6 +381,39 @@ When a rate limit or transient error occurs:
 - For free tier quotas, lower concurrency or use LiteLLM client (has built-in retry)
 - Wait 60s between runs to resets quota
 
+### Pre-Screening (`main.yaml`)
+
+Embedding-based resume ranking for cost reduction. Filters a folder of
+resumes down to a top-K subset before the expensive LLM evaluation phase.
+
+```yaml
+pre_screening:
+  enabled: true
+  embedding_model: "mistral/mistral-embed"
+  top_k: 20
+  bm25_weight: 0.3
+  embedding_weight: 0.7
+  bm25_min_score: 0.0
+  bm25_min_overlap_ratio: 0.0
+  embedding_cache_size: 512
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Enable pre-screening |
+| `embedding_model` | `mistral/mistral-embed` | LiteLLM model string for embeddings |
+| `top_k` | `20` | Number of candidates to keep after filtering |
+| `bm25_weight` | `0.3` | Weight for BM25 keyword matching score |
+| `embedding_weight` | `0.7` | Weight for dense embedding cosine similarity |
+| `bm25_min_score` | `0.0` | Minimum BM25 score to pass Tier 1 |
+| `bm25_min_overlap_ratio` | `0.0` | Minimum entity overlap ratio to pass Tier 1 |
+| `embedding_cache_size` | `512` | LRU cache size for embedding lookups |
+
+Two-tier pipeline: Tier 1 uses BM25 keyword matching on extracted named
+entities; Tier 2 uses dense embedding cosine similarity. Scores are
+combined with configurable weights. Override `top_k` via CLI:
+`--pre-screen 10`.
+
 ### Model Defaults (`model_defaults.yaml`)
 
 ```yaml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -390,11 +390,10 @@ resumes down to a top-K subset before the expensive LLM evaluation phase.
 pre_screening:
   enabled: true
   embedding_model: "mistral/mistral-embed"
-  top_k: 20
   bm25_weight: 0.3
   embedding_weight: 0.7
   bm25_min_score: 0.0
-  bm25_min_overlap_ratio: 0.0
+  bm25_min_overlap_ratio: 0.05
   embedding_cache_size: 512
 ```
 
@@ -402,17 +401,18 @@ pre_screening:
 |---------|---------|-------------|
 | `enabled` | `true` | Enable pre-screening |
 | `embedding_model` | `mistral/mistral-embed` | LiteLLM model string for embeddings |
-| `top_k` | `20` | Number of candidates to keep after filtering |
-| `bm25_weight` | `0.3` | Weight for BM25 keyword matching score |
-| `embedding_weight` | `0.7` | Weight for dense embedding cosine similarity |
-| `bm25_min_score` | `0.0` | Minimum BM25 score to pass Tier 1 |
-| `bm25_min_overlap_ratio` | `0.0` | Minimum entity overlap ratio to pass Tier 1 |
+| `bm25_weight` | `0.3` | Weight for BM25 score in combined ranking of survivors |
+| `embedding_weight` | `0.7` | Weight for embedding similarity in combined ranking of survivors |
+| `bm25_min_score` | `0.0` | Minimum BM25 score — candidates below are excluded (hard gate) |
+| `bm25_min_overlap_ratio` | `0.05` | Minimum entity overlap ratio — candidates below are excluded (hard gate) |
 | `embedding_cache_size` | `512` | LRU cache size for embedding lookups |
 
-Two-tier pipeline: Tier 1 uses BM25 keyword matching on extracted named
-entities; Tier 2 uses dense embedding cosine similarity. Scores are
-combined with configurable weights. Override `top_k` via CLI:
-`--pre-screen 10`.
+Two-tier pipeline: Tier 1 is a **hard exclusion** gate using BM25 keyword
+matching on extracted named entities — candidates below `bm25_min_score` or
+`bm25_min_overlap_ratio` are removed entirely. Tier 2 uses dense embedding
+cosine similarity to rank survivors, with scores combined using configurable
+weights. Specify the number of candidates to keep via CLI:
+`--pre-screen 10` (required, no config default).
 
 ### Model Defaults (`model_defaults.yaml`)
 

--- a/docs/ORCHESTRATOR README.md
+++ b/docs/ORCHESTRATOR README.md
@@ -1409,7 +1409,7 @@ python scripts/sample_workbook_screening_validate_v001.py [workbook_path]
 ```
 
 Document evaluation pipeline with per-row documents, scoring rubric, and synthesis ranking.
-Supports `--pre-screen [N]` on creation scripts for embedding-based cost reduction.
+Supports `--pre-screen N` (N required) on creation scripts for embedding-based cost reduction.
 
 #### Screening v002 Sample Workbook (Planning Phase)
 

--- a/docs/ORCHESTRATOR README.md
+++ b/docs/ORCHESTRATOR README.md
@@ -754,6 +754,9 @@ inv screening.create -r ./resumes/ -j ./jd.md        # Create workbook
 inv screening.run -r ./resumes/ -j ./jd.md          # Create and run
 inv screening.manifest -r ./resumes/ -j ./jd.md     # Create and run manifest
 inv screening.inspect ./screening.xlsx                # Inspect results
+
+# With pre-screening (filter to top-20 before LLM evaluation)
+inv screening.manifest -r ./resumes/ -j ./jd.md --pre-screen 20
 ```
 
 ### Discovery Functions
@@ -1239,6 +1242,7 @@ inv rag.stats       # Show detailed RAG statistics
 inv screening.create -r ./resumes/ -j ./jd.md
 inv screening.run -r ./resumes/ -j ./jd.md
 inv screening.manifest -r ./resumes/ -j ./jd.md
+inv screening.manifest -r ./resumes/ -j ./jd.md --pre-screen 10  # Filter to top-10
 inv screening.inspect ./screening.xlsx
 ```
 
@@ -1405,6 +1409,7 @@ python scripts/sample_workbook_screening_validate_v001.py [workbook_path]
 ```
 
 Document evaluation pipeline with per-row documents, scoring rubric, and synthesis ranking.
+Supports `--pre-screen [N]` on creation scripts for embedding-based cost reduction.
 
 #### Screening v002 Sample Workbook (Planning Phase)
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -218,6 +218,7 @@ Same manifest. Same execution engine. Same audit trail.
 - Shared document support (e.g., a job description for all rows)
 - Integration with ExcelOrchestrator and ManifestOrchestrator via `documents_path`/`shared_document_path`
 - Resume screening use case with dedicated invoke tasks
+- Pre-screening via embedding similarity and BM25 ranking for cost reduction
 
 **See:** [ORCHESTRATOR README.md](../ORCHESTRATOR%20README.md) for discovery usage.
 

--- a/scripts/create_screening_manifest.py
+++ b/scripts/create_screening_manifest.py
@@ -75,6 +75,7 @@ from sample_workbooks.screening import (
 
 from src.config import get_config
 from src.orchestrator.discovery import discover_documents
+from src.orchestrator.pre_screener import ResumePreScreener
 
 load_dotenv()
 
@@ -100,6 +101,7 @@ def build_manifest_yaml(
     prompt_count: int,
     has_documents: bool = False,
     has_clients: bool = False,
+    has_data: bool = False,
 ) -> dict[str, Any]:
     """Build manifest.yaml metadata.
 
@@ -109,6 +111,7 @@ def build_manifest_yaml(
         prompt_count: Number of prompts.
         has_documents: Whether documents.yaml was written.
         has_clients: Whether clients.yaml was written.
+        has_data: Whether data.yaml was written (pre-screening).
 
     Returns:
         Manifest metadata dict.
@@ -119,7 +122,7 @@ def build_manifest_yaml(
         "description": f"Screening evaluation ({'planning' if planning else 'static scoring'})",
         "version": "1.0",
         "exported_at": datetime.now().isoformat(),
-        "has_data": False,
+        "has_data": has_data,
         "has_clients": has_clients,
         "has_documents": has_documents,
         "has_tools": False,
@@ -321,6 +324,17 @@ def main() -> int:
         help="Custom synthesis prompt template (name in config/prompts/ or file path). "
         "Default: config/prompts/screening_synthesis.yaml",
     )
+    parser.add_argument(
+        "--pre-screen",
+        nargs="?",
+        const=-1,
+        type=int,
+        default=None,
+        metavar="N",
+        help="Enable embedding-based pre-screening to rank and filter resumes "
+        "before creating the manifest. Reduces LLM costs by only evaluating "
+        "top-K candidates. Optionally specify N to override config default.",
+    )
 
     args = parser.parse_args()
 
@@ -330,6 +344,12 @@ def main() -> int:
         print("Warning: --planning-client has no effect without --planning.\n")
     if args.static_prompts and args.planning:
         print("Warning: --static-prompts has no effect with --planning (use --planning-prompts).\n")
+    if args.pre_screen is not None and not args.jd:
+        print("Error: --pre-screen requires --jd (need JD text for embedding comparison).\n")
+        return 1
+    if args.pre_screen is not None and not args.resumes_path:
+        print("Error: --pre-screen requires --resumes-path.\n")
+        return 1
 
     if not args.resumes_path and not args.jd:
         print("Note: Neither --resumes-path nor --jd provided.")
@@ -360,6 +380,8 @@ def main() -> int:
         return 1
 
     resume_count = 0
+    pre_screen_report = None
+    filtered_doc_specs = None
     if args.resumes_path:
         resume_docs = discover_documents(
             args.resumes_path,
@@ -372,6 +394,46 @@ def main() -> int:
             print(f"  Discovered {resume_count} documents")
         else:
             print(f"  Warning: No documents found in {args.resumes_path}")
+
+        if args.pre_screen is not None and resume_count > 0:
+            top_k = args.pre_screen if args.pre_screen > 0 else config.pre_screening.top_k
+            print(f"\n  Pre-screening enabled (top-{top_k} of {resume_count})")
+            print(f"  Embedding model: {config.pre_screening.embedding_model}")
+            print(
+                f"  Weights: BM25={config.pre_screening.bm25_weight}, "
+                f"embedding={config.pre_screening.embedding_weight}"
+            )
+
+            jd_text = Path(args.jd).read_text(encoding="utf-8")
+
+            pre_screener = ResumePreScreener(
+                embedding_model=config.pre_screening.embedding_model,
+                bm25_weight=config.pre_screening.bm25_weight,
+                embedding_weight=config.pre_screening.embedding_weight,
+                bm25_min_score=config.pre_screening.bm25_min_score,
+                bm25_min_overlap_ratio=config.pre_screening.bm25_min_overlap_ratio,
+                embedding_cache_size=config.pre_screening.embedding_cache_size,
+            )
+            ranked = pre_screener.rank_resumes(jd_text, args.resumes_path, extensions=extensions)
+            filtered = pre_screener.filter_to_top_k(ranked, top_k)
+            filtered_doc_specs = pre_screener.build_document_specs(filtered)
+            pre_screen_report = pre_screener.build_report(ranked, top_k)
+
+            resume_count = len(filtered)
+            print("\n  Pre-screening results:")
+            print(f"    Total candidates:   {pre_screen_report['total_candidates']}")
+            print(f"    BM25 filtered out:  {pre_screen_report['bm25_filtered']}")
+            print(f"    Selected (top-{top_k}):    {len(filtered)}")
+            if filtered:
+                print(
+                    f"    Best match:         {filtered[0].common_name} "
+                    f"(score={filtered[0].combined_score:.4f})"
+                )
+                if len(filtered) > 1:
+                    print(
+                        f"    Worst selected:     {filtered[-1].common_name} "
+                        f"(score={filtered[-1].combined_score:.4f})"
+                    )
 
     synthesis_top_n = (
         max(resume_count, DEFAULT_SYNTHESIS_TOP_N) if resume_count > 0 else DEFAULT_SYNTHESIS_TOP_N
@@ -397,6 +459,7 @@ def main() -> int:
     )
 
     has_documents = args.jd is not None
+    has_data = filtered_doc_specs is not None
 
     write_yaml(
         manifest_path / "manifest.yaml",
@@ -406,6 +469,7 @@ def main() -> int:
             len(prompts),
             has_documents=has_documents,
             has_clients=planning_client_type is not None,
+            has_data=has_data,
         ),
     )
     write_yaml(
@@ -462,10 +526,32 @@ def main() -> int:
 
     if args.jd:
         jd_doc = create_jd_document(args.jd)
+        docs_list = [jd_doc]
+        if filtered_doc_specs is not None:
+            docs_list.extend(filtered_doc_specs)
+            write_yaml(
+                manifest_path / "data.yaml",
+                {
+                    "batches": [
+                        {
+                            "id": i,
+                            "batch_name": r["reference_name"],
+                            "candidate_name": r["common_name"],
+                            "_documents": f'["{r["reference_name"]}"]',
+                        }
+                        for i, r in enumerate(filtered_doc_specs, start=1)
+                    ]
+                },
+            )
         write_yaml(
             manifest_path / "documents.yaml",
-            build_documents_yaml([jd_doc]),
+            build_documents_yaml(docs_list),
         )
+        if pre_screen_report is not None:
+            write_yaml(
+                manifest_path / "pre_screening_report.yaml",
+                pre_screen_report,
+            )
 
     total_prompts = len(prompts)
     if args.planning:
@@ -488,7 +574,13 @@ def main() -> int:
     else:
         print("Job description: inject at runtime (--shared-document)")
     if resume_count > 0:
-        print(f"Resumes:         {resume_count} discovered (injected at runtime)")
+        if args.pre_screen is not None and pre_screen_report:
+            print(
+                f"Resumes:         {pre_screen_report['total_candidates']} discovered, "
+                f"{resume_count} after pre-screening (baked in)"
+            )
+        else:
+            print(f"Resumes:         {resume_count} discovered (injected at runtime)")
     else:
         print("Resumes:         inject at runtime (--documents-path)")
     print(f"Prompts:         {prompt_summary}")
@@ -510,8 +602,14 @@ def main() -> int:
         print(f"Templates:       {', '.join(sources)}")
 
     if args.jd:
-        print("\nRun with:")
-        print(f"  python scripts/manifest_run.py {manifest_path} --documents-path ./resumes/ -c 1")
+        if filtered_doc_specs is not None:
+            print("\nRun with:")
+            print(f"  python scripts/manifest_run.py {manifest_path} -c 5")
+        else:
+            print("\nRun with:")
+            print(
+                f"  python scripts/manifest_run.py {manifest_path} --documents-path ./resumes/ -c 1"
+            )
     else:
         print("\nRun with:")
         print(

--- a/scripts/create_screening_manifest.py
+++ b/scripts/create_screening_manifest.py
@@ -326,14 +326,12 @@ def main() -> int:
     )
     parser.add_argument(
         "--pre-screen",
-        nargs="?",
-        const=-1,
         type=int,
         default=None,
         metavar="N",
         help="Enable embedding-based pre-screening to rank and filter resumes "
         "before creating the manifest. Reduces LLM costs by only evaluating "
-        "top-K candidates. Optionally specify N to override config default.",
+        "top-N candidates. Requires an explicit N value (e.g., --pre-screen 10).",
     )
 
     args = parser.parse_args()
@@ -396,7 +394,12 @@ def main() -> int:
             print(f"  Warning: No documents found in {args.resumes_path}")
 
         if args.pre_screen is not None and resume_count > 0:
-            top_k = args.pre_screen if args.pre_screen > 0 else config.pre_screening.top_k
+            if args.pre_screen <= 0:
+                print(
+                    "Error: --pre-screen requires a positive integer value (e.g., --pre-screen 10).\n"
+                )
+                return 1
+            top_k = args.pre_screen
             print(f"\n  Pre-screening enabled (top-{top_k} of {resume_count})")
             print(f"  Embedding model: {config.pre_screening.embedding_model}")
             print(
@@ -414,16 +417,24 @@ def main() -> int:
                 bm25_min_overlap_ratio=config.pre_screening.bm25_min_overlap_ratio,
                 embedding_cache_size=config.pre_screening.embedding_cache_size,
             )
-            ranked = pre_screener.rank_resumes(jd_text, args.resumes_path, extensions=extensions)
+            ranked, bm25_excluded = pre_screener.rank_resumes(
+                jd_text, args.resumes_path, extensions=extensions
+            )
             filtered = pre_screener.filter_to_top_k(ranked, top_k)
             filtered_doc_specs = pre_screener.build_document_specs(filtered)
-            pre_screen_report = pre_screener.build_report(ranked, top_k)
+            pre_screen_report = pre_screener.build_report(
+                ranked,
+                top_k,
+                total_discovered=resume_count,
+                bm25_excluded=bm25_excluded,
+            )
 
             resume_count = len(filtered)
             print("\n  Pre-screening results:")
-            print(f"    Total candidates:   {pre_screen_report['total_candidates']}")
-            print(f"    BM25 filtered out:  {pre_screen_report['bm25_filtered']}")
-            print(f"    Selected (top-{top_k}):    {len(filtered)}")
+            print(f"    Discovered:         {pre_screen_report['total_discovered']}")
+            print(f"    BM25 excluded:      {pre_screen_report['bm25_excluded']}")
+            print(f"    After BM25:         {pre_screen_report['after_bm25']}")
+            print(f"    Selected (top-{top_k}):  {len(filtered)}")
             if filtered:
                 print(
                     f"    Best match:         {filtered[0].common_name} "
@@ -576,8 +587,9 @@ def main() -> int:
     if resume_count > 0:
         if args.pre_screen is not None and pre_screen_report:
             print(
-                f"Resumes:         {pre_screen_report['total_candidates']} discovered, "
-                f"{resume_count} after pre-screening (baked in)"
+                f"Resumes:         {pre_screen_report['total_discovered']} discovered, "
+                f"{pre_screen_report['bm25_excluded']} excluded by BM25, "
+                f"{resume_count} selected (baked in)"
             )
         else:
             print(f"Resumes:         {resume_count} discovered (injected at runtime)")

--- a/scripts/create_screening_workbook.py
+++ b/scripts/create_screening_workbook.py
@@ -157,14 +157,12 @@ def main() -> int:
     )
     parser.add_argument(
         "--pre-screen",
-        nargs="?",
-        const=-1,
         type=int,
         default=None,
         metavar="N",
         help="Enable embedding-based pre-screening to rank and filter resumes "
         "before baking them into the workbook. Reduces LLM costs by only evaluating "
-        "top-K candidates. Optionally specify N to override config default.",
+        "top-N candidates. Requires an explicit N value (e.g., --pre-screen 10).",
     )
 
     args = parser.parse_args()
@@ -236,7 +234,12 @@ def main() -> int:
         print(f"  Discovered {len(resume_docs)} documents")
 
         if args.pre_screen is not None:
-            top_k = args.pre_screen if args.pre_screen > 0 else config.pre_screening.top_k
+            if args.pre_screen <= 0:
+                print(
+                    "Error: --pre-screen requires a positive integer value (e.g., --pre-screen 10).\n"
+                )
+                return 1
+            top_k = args.pre_screen
             print(f"\n  Pre-screening enabled (top-{top_k} of {len(resume_docs)})")
             print(f"  Embedding model: {config.pre_screening.embedding_model}")
             print(
@@ -256,10 +259,17 @@ def main() -> int:
                 bm25_min_overlap_ratio=config.pre_screening.bm25_min_overlap_ratio,
                 embedding_cache_size=config.pre_screening.embedding_cache_size,
             )
-            ranked = pre_screener.rank_resumes(jd_text, args.resumes_path, extensions=extensions)
+            ranked, bm25_excluded = pre_screener.rank_resumes(
+                jd_text, args.resumes_path, extensions=extensions
+            )
             filtered = pre_screener.filter_to_top_k(ranked, top_k)
             filtered_doc_specs = pre_screener.build_document_specs(filtered)
-            pre_screen_report = pre_screener.build_report(ranked, top_k)
+            pre_screen_report = pre_screener.build_report(
+                ranked,
+                top_k,
+                total_discovered=len(resume_docs),
+                bm25_excluded=bm25_excluded,
+            )
 
             resume_docs = [
                 d
@@ -268,9 +278,10 @@ def main() -> int:
             ]
 
             print("\n  Pre-screening results:")
-            print(f"    Total candidates:   {pre_screen_report['total_candidates']}")
-            print(f"    BM25 filtered out:  {pre_screen_report['bm25_filtered']}")
-            print(f"    Selected (top-{top_k}):    {len(filtered)}")
+            print(f"    Discovered:         {pre_screen_report['total_discovered']}")
+            print(f"    BM25 excluded:      {pre_screen_report['bm25_excluded']}")
+            print(f"    After BM25:         {pre_screen_report['after_bm25']}")
+            print(f"    Selected (top-{top_k}):  {len(filtered)}")
             if filtered:
                 print(
                     f"    Best match:         {filtered[0].common_name} "
@@ -420,7 +431,7 @@ def main() -> int:
         summary_extra["Job description"] = jd_doc["file_path"]
     if candidate_count > 0:
         if args.pre_screen is not None and pre_screen_report:
-            summary_extra["Resumes discovered"] = str(pre_screen_report["total_candidates"])
+            summary_extra["Resumes discovered"] = str(pre_screen_report["total_discovered"])
             summary_extra["Pre-screened (top-K)"] = str(candidate_count)
         else:
             summary_extra["Resumes discovered"] = str(candidate_count)

--- a/scripts/create_screening_workbook.py
+++ b/scripts/create_screening_workbook.py
@@ -65,6 +65,7 @@ from src.orchestrator.discovery import (
     create_data_rows_from_documents,
     discover_documents,
 )
+from src.orchestrator.pre_screener import ResumePreScreener
 
 load_dotenv()
 
@@ -154,6 +155,17 @@ def main() -> int:
         help="Custom synthesis prompt template (name in config/prompts/ or file path). "
         "Default: config/prompts/screening_synthesis.yaml",
     )
+    parser.add_argument(
+        "--pre-screen",
+        nargs="?",
+        const=-1,
+        type=int,
+        default=None,
+        metavar="N",
+        help="Enable embedding-based pre-screening to rank and filter resumes "
+        "before baking them into the workbook. Reduces LLM costs by only evaluating "
+        "top-K candidates. Optionally specify N to override config default.",
+    )
 
     args = parser.parse_args()
 
@@ -163,6 +175,12 @@ def main() -> int:
         print("Warning: --planning-client has no effect without --planning.\n")
     if args.static_prompts and args.planning:
         print("Warning: --static-prompts has no effect with --planning (use --planning-prompts).\n")
+    if args.pre_screen is not None and not args.jd:
+        print("Error: --pre-screen requires --jd (need JD text for embedding comparison).\n")
+        return 1
+    if args.pre_screen is not None and not args.resumes_path:
+        print("Error: --pre-screen requires --resumes-path.\n")
+        return 1
 
     if not args.resumes_path and not args.jd:
         print("Note: Neither --resumes-path nor --jd provided.")
@@ -196,6 +214,7 @@ def main() -> int:
     all_documents: list[dict[str, str | list[str]]] = []
     data_rows: list[dict[str, str | int]] = []
     resume_docs: list[dict[str, str | list[str]]] = []
+    pre_screen_report = None
 
     if args.jd:
         jd_doc = create_jd_document(args.jd)
@@ -215,6 +234,54 @@ def main() -> int:
             return 1
 
         print(f"  Discovered {len(resume_docs)} documents")
+
+        if args.pre_screen is not None:
+            top_k = args.pre_screen if args.pre_screen > 0 else config.pre_screening.top_k
+            print(f"\n  Pre-screening enabled (top-{top_k} of {len(resume_docs)})")
+            print(f"  Embedding model: {config.pre_screening.embedding_model}")
+            print(
+                f"  Weights: BM25={config.pre_screening.bm25_weight}, "
+                f"embedding={config.pre_screening.embedding_weight}"
+            )
+
+            from pathlib import Path
+
+            jd_text = Path(args.jd).read_text(encoding="utf-8")
+
+            pre_screener = ResumePreScreener(
+                embedding_model=config.pre_screening.embedding_model,
+                bm25_weight=config.pre_screening.bm25_weight,
+                embedding_weight=config.pre_screening.embedding_weight,
+                bm25_min_score=config.pre_screening.bm25_min_score,
+                bm25_min_overlap_ratio=config.pre_screening.bm25_min_overlap_ratio,
+                embedding_cache_size=config.pre_screening.embedding_cache_size,
+            )
+            ranked = pre_screener.rank_resumes(jd_text, args.resumes_path, extensions=extensions)
+            filtered = pre_screener.filter_to_top_k(ranked, top_k)
+            filtered_doc_specs = pre_screener.build_document_specs(filtered)
+            pre_screen_report = pre_screener.build_report(ranked, top_k)
+
+            resume_docs = [
+                d
+                for d in resume_docs
+                if any(d["reference_name"] == s["reference_name"] for s in filtered_doc_specs)
+            ]
+
+            print("\n  Pre-screening results:")
+            print(f"    Total candidates:   {pre_screen_report['total_candidates']}")
+            print(f"    BM25 filtered out:  {pre_screen_report['bm25_filtered']}")
+            print(f"    Selected (top-{top_k}):    {len(filtered)}")
+            if filtered:
+                print(
+                    f"    Best match:         {filtered[0].common_name} "
+                    f"(score={filtered[0].combined_score:.4f})"
+                )
+                if len(filtered) > 1:
+                    print(
+                        f"    Worst selected:     {filtered[-1].common_name} "
+                        f"(score={filtered[-1].combined_score:.4f})"
+                    )
+
         all_documents.extend(resume_docs)
         data_rows = create_data_rows_from_documents(resume_docs)
 
@@ -308,6 +375,18 @@ def main() -> int:
 
     builder.save()
 
+    if pre_screen_report is not None:
+        from pathlib import Path
+
+        import yaml
+
+        report_path = str(Path(args.output).with_suffix(".pre_screening_report.yaml"))
+        Path(report_path).write_text(
+            yaml.dump(pre_screen_report, default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )
+        print(f"  Pre-screening report: {report_path}")
+
     total_prompts = len(prompts)
     if args.planning:
         planning_count = sum(1 for p in prompts if p.phase == "planning")
@@ -340,7 +419,11 @@ def main() -> int:
     if args.jd:
         summary_extra["Job description"] = jd_doc["file_path"]
     if candidate_count > 0:
-        summary_extra["Resumes discovered"] = str(candidate_count)
+        if args.pre_screen is not None and pre_screen_report:
+            summary_extra["Resumes discovered"] = str(pre_screen_report["total_candidates"])
+            summary_extra["Pre-screened (top-K)"] = str(candidate_count)
+        else:
+            summary_extra["Resumes discovered"] = str(candidate_count)
         summary_extra["Candidates (batch rows)"] = str(candidate_count)
         summary_extra["Total batch executions"] = (
             f"{total_prompts} prompts x {candidate_count} candidates = "
@@ -348,11 +431,12 @@ def main() -> int:
         )
 
     run_flags: list[str] = []
-    if args.jd and not args.resumes_path:
-        run_flags.append("--documents-path ./resumes/")
-    elif not args.jd:
-        run_flags.append("--shared-document ./jd.md --shared-document-name job_description")
-        run_flags.append("--documents-path ./resumes/")
+    if args.pre_screen is None:
+        if args.jd and not args.resumes_path:
+            run_flags.append("--documents-path ./resumes/")
+        elif not args.jd:
+            run_flags.append("--shared-document ./jd.md --shared-document-name job_description")
+            run_flags.append("--documents-path ./resumes/")
     run_command = f"python scripts/run_orchestrator.py {args.output} -c 1"
     if run_flags:
         run_command += " \\\n    " + " \\\n    ".join(run_flags)

--- a/scripts/manifest_run.py
+++ b/scripts/manifest_run.py
@@ -307,27 +307,18 @@ def main():
     print(f"Concurrency:   {args.concurrency}")
 
     if pre_screen_report:
-        total_discovered = pre_screen_report.get("total_candidates", 0)
-        bm25_filtered = pre_screen_report.get("bm25_filtered", 0)
-        top_k_selected = pre_screen_report.get("top_k_selected", 0)
-        selected_names = {
-            c["reference_name"]
-            for c in pre_screen_report.get("selected_candidates", [])
-            if "reference_name" in c
-        }
-        all_candidates = pre_screen_report.get("all_candidates", [])
-        bm25_filtered_not_selected = sum(
-            1
-            for c in all_candidates
-            if not c.get("passed_bm25", True) and c.get("reference_name") not in selected_names
-        )
-        embedding_excluded = total_discovered - bm25_filtered_not_selected - top_k_selected
+        total_discovered = pre_screen_report.get("total_discovered", 0)
+        bm25_excluded = pre_screen_report.get("bm25_excluded", 0)
+        after_bm25 = pre_screen_report.get("after_bm25", 0)
+        top_k_excluded = pre_screen_report.get("top_k_excluded", 0)
+        evaluated_by_llm = pre_screen_report.get("evaluated_by_llm", 0)
         print()
         print("Screening Pipeline:")
         print(f"  Discovered:         {total_discovered}")
-        print(f"  BM25 filtered:      {bm25_filtered}")
-        print(f"  Embedding excluded: {embedding_excluded}")
-        print(f"  Evaluated by LLM:   {top_k_selected}")
+        print(f"  BM25 excluded:      {bm25_excluded}")
+        print(f"  After BM25:         {after_bm25}")
+        print(f"  Top-K excluded:     {top_k_excluded}")
+        print(f"  Evaluated by LLM:   {evaluated_by_llm}")
 
     if summary.get("total_batches"):
         candidates_with_aborted_prompts = 0

--- a/scripts/manifest_run.py
+++ b/scripts/manifest_run.py
@@ -293,16 +293,64 @@ def main():
 
     summary = orchestrator.get_summary()
 
+    pre_screen_report = None
+    pre_screen_yaml = os.path.join(manifest_dir, "pre_screening_report.yaml")
+    if os.path.exists(pre_screen_yaml):
+        with open(pre_screen_yaml, encoding="utf-8") as f:
+            pre_screen_report = yaml.safe_load(f)
+
     print("\n" + "=" * 60)
     print("ORCHESTRATION COMPLETE")
     print("=" * 60)
     print(f"Manifest:      {manifest_dir}")
     print(f"Parquet:       {parquet_path}")
     print(f"Concurrency:   {args.concurrency}")
+
+    if pre_screen_report:
+        total_discovered = pre_screen_report.get("total_candidates", 0)
+        bm25_filtered = pre_screen_report.get("bm25_filtered", 0)
+        top_k_selected = pre_screen_report.get("top_k_selected", 0)
+        selected_names = {
+            c["reference_name"]
+            for c in pre_screen_report.get("selected_candidates", [])
+            if "reference_name" in c
+        }
+        all_candidates = pre_screen_report.get("all_candidates", [])
+        bm25_filtered_not_selected = sum(
+            1
+            for c in all_candidates
+            if not c.get("passed_bm25", True) and c.get("reference_name") not in selected_names
+        )
+        embedding_excluded = total_discovered - bm25_filtered_not_selected - top_k_selected
+        print()
+        print("Screening Pipeline:")
+        print(f"  Discovered:         {total_discovered}")
+        print(f"  BM25 filtered:      {bm25_filtered}")
+        print(f"  Embedding excluded: {embedding_excluded}")
+        print(f"  Evaluated by LLM:   {top_k_selected}")
+
+    if summary.get("total_batches"):
+        candidates_with_aborted_prompts = 0
+        if hasattr(orchestrator, "results") and orchestrator.results:
+            batch_names_with_abort = set()
+            for r in orchestrator.results:
+                if r.get("status") == "aborted" and r.get("batch_name"):
+                    batch_names_with_abort.add(r["batch_name"])
+            candidates_with_aborted_prompts = len(batch_names_with_abort)
+        if candidates_with_aborted_prompts > 0:
+            print(
+                f"  LLM suspended:    {candidates_with_aborted_prompts} candidates had aborted prompts"
+            )
+
+    print()
     print(f"Total prompts: {summary['total_prompts']}")
     print(f"Successful:    {summary['successful']}")
     print(f"Aborted:       {summary['aborted']}")
     print(f"Failed:        {summary['failed']}")
+    if summary.get("tokens"):
+        print(f"Tokens:        {summary['tokens']['total']:,}")
+    if summary.get("cost_usd") is not None:
+        print(f"Cost:          ${summary['cost_usd']:.6f}")
     print("=" * 60 + "\n")
 
     print(f"Extract results: python scripts/manifest_extract.py {parquet_path} --save\n")

--- a/scripts/run_orchestrator.py
+++ b/scripts/run_orchestrator.py
@@ -40,6 +40,7 @@ from dotenv import load_dotenv
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import yaml
 from _shared import ProgressIndicator, get_client, setup_logging
 
 from src.config import get_config
@@ -256,16 +257,55 @@ def main():
 
     summary = orchestrator.get_summary()
 
+    pre_screen_report = None
+    report_path = os.path.splitext(workbook_path)[0] + ".pre_screening_report.yaml"
+    if os.path.exists(report_path):
+        with open(report_path, encoding="utf-8") as f:
+            pre_screen_report = yaml.safe_load(f)
+
     print("\n" + "=" * 60)
     print("ORCHESTRATION COMPLETE")
     print("=" * 60)
     print(f"Workbook:      {summary['workbook']}")
     print(f"Results sheet: {results_sheet}")
     print(f"Concurrency:   {args.concurrency}")
+
+    if pre_screen_report:
+        total_discovered = pre_screen_report.get("total_discovered", 0)
+        bm25_excluded = pre_screen_report.get("bm25_excluded", 0)
+        after_bm25 = pre_screen_report.get("after_bm25", 0)
+        top_k_excluded = pre_screen_report.get("top_k_excluded", 0)
+        evaluated_by_llm = pre_screen_report.get("evaluated_by_llm", 0)
+        print()
+        print("Screening Pipeline:")
+        print(f"  Discovered:         {total_discovered}")
+        print(f"  BM25 excluded:      {bm25_excluded}")
+        print(f"  After BM25:         {after_bm25}")
+        print(f"  Top-K excluded:     {top_k_excluded}")
+        print(f"  Evaluated by LLM:   {evaluated_by_llm}")
+
+    if summary.get("total_batches"):
+        candidates_with_aborted_prompts = 0
+        if hasattr(orchestrator, "results") and orchestrator.results:
+            batch_names_with_abort = set()
+            for r in orchestrator.results:
+                if r.get("status") == "aborted" and r.get("batch_name"):
+                    batch_names_with_abort.add(r["batch_name"])
+            candidates_with_aborted_prompts = len(batch_names_with_abort)
+        if candidates_with_aborted_prompts > 0:
+            print(
+                f"  LLM suspended:    {candidates_with_aborted_prompts} candidates had aborted prompts"
+            )
+
+    print()
     print(f"Total prompts: {summary['total_prompts']}")
     print(f"Successful:    {summary['successful']}")
     print(f"Aborted:       {summary['aborted']}")
     print(f"Failed:        {summary['failed']}")
+    if summary.get("tokens"):
+        print(f"Tokens:        {summary['tokens']['total']:,}")
+    if summary.get("cost_usd") is not None:
+        print(f"Cost:          ${summary['cost_usd']:.6f}")
     print("=" * 60 + "\n")
 
     return 0 if summary["failed"] == 0 else 1

--- a/src/config.py
+++ b/src/config.py
@@ -495,7 +495,6 @@ class PreScreeningConfig(BaseSettings):
 
     enabled: bool = True
     embedding_model: str = "mistral/mistral-embed"
-    top_k: int = 20
     bm25_weight: float = 0.3
     embedding_weight: float = 0.7
     bm25_min_score: float = 0.0

--- a/src/config.py
+++ b/src/config.py
@@ -66,6 +66,7 @@ def _load_all_configs() -> dict[str, Any]:
         "model_defaults": _load_yaml_file("model_defaults.yaml").get("model_defaults", {}),
         "sample": _load_yaml_file("sample_workbook.yaml").get("sample_workbooks", {}),
         "observability": _load_yaml_file("main.yaml").get("observability", {}),
+        "pre_screening": _load_yaml_file("main.yaml").get("pre_screening", {}),
     }
 
 
@@ -489,6 +490,19 @@ class ObservabilityConfig(BaseSettings):
     cost_tracking: bool = True
 
 
+class PreScreeningConfig(BaseSettings):
+    """Pre-screening configuration for embedding-based resume ranking."""
+
+    enabled: bool = True
+    embedding_model: str = "mistral/mistral-embed"
+    top_k: int = 20
+    bm25_weight: float = 0.3
+    embedding_weight: float = 0.7
+    bm25_min_score: float = 0.0
+    bm25_min_overlap_ratio: float = 0.0
+    embedding_cache_size: int = 512
+
+
 class Config(BaseSettings):
     """Main configuration class."""
 
@@ -512,6 +526,7 @@ class Config(BaseSettings):
     model_defaults: ModelDefaultsConfig = Field(default_factory=ModelDefaultsConfig)
     sample: SampleConfig = Field(default_factory=SampleConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
+    pre_screening: PreScreeningConfig = Field(default_factory=PreScreeningConfig)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/config.py
+++ b/src/config.py
@@ -499,7 +499,7 @@ class PreScreeningConfig(BaseSettings):
     bm25_weight: float = 0.3
     embedding_weight: float = 0.7
     bm25_min_score: float = 0.0
-    bm25_min_overlap_ratio: float = 0.0
+    bm25_min_overlap_ratio: float = 0.05
     embedding_cache_size: int = 512
 
 

--- a/src/orchestrator/pre_screener.py
+++ b/src/orchestrator/pre_screener.py
@@ -28,12 +28,16 @@ from .document_processor import DocumentProcessor
 logger = logging.getLogger(__name__)
 
 _ENTITY_RE = re.compile(
-    r"\b(?:"
+    r"(?:"
     r"[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+"  # multi-word: "Google Cloud Platform"
     r"|[A-Z][a-z]+[A-Z][A-Za-z]*"  # camelCase: "BigQuery", "JavaScript"
     r"|[A-Z]{2,}"  # acronyms: "GCP", "SQL"
+    r"|[A-Z]\+\+"  # C++, F++
+    r"|[A-Z]#"  # C#, F#
+    r"|\.NET"  # .NET
+    r"|[A-Z][a-z]+\.js"  # Node.js, Vue.js, React.js
     r"|[A-Z][a-z]+"  # single capitalized: "Python"
-    r")\b"
+    r")(?=\b|[^a-zA-Z0-9]|$)"
 )
 
 _STOPWORDS = frozenset(
@@ -124,6 +128,66 @@ _STOPWORDS = frozenset(
         "Looking",
         "Required",
         "Preferred",
+        "Senior",
+        "Junior",
+        "Lead",
+        "Manager",
+        "Director",
+        "Coordinator",
+        "Specialist",
+        "Analyst",
+        "Consultant",
+        "Associate",
+        "Assistant",
+        "Executive",
+        "Intern",
+        "Team",
+        "Group",
+        "Department",
+        "Division",
+        "Company",
+        "Organization",
+        "Corporation",
+        "University",
+        "College",
+        "Institute",
+        "Development",
+        "Engineering",
+        "Management",
+        "Operations",
+        "Research",
+        "Design",
+        "Analysis",
+        "Strategy",
+        "Planning",
+        "Implementation",
+        "Maintenance",
+        "Support",
+        "Service",
+        "Services",
+        "Solutions",
+        "Systems",
+        "Platform",
+        "Platforms",
+        "Technology",
+        "Technologies",
+        "Product",
+        "Products",
+        "Project",
+        "Projects",
+        "Program",
+        "Programs",
+        "January",
+        "February",
+        "March",
+        "April",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
     }
 )
 

--- a/src/orchestrator/pre_screener.py
+++ b/src/orchestrator/pre_screener.py
@@ -281,13 +281,13 @@ class ResumePreScreener:
         jd_text: str,
         resumes_folder: str | Path,
         extensions: set[str] | None = None,
-    ) -> list[RankedResume]:
+    ) -> tuple[list[RankedResume], int]:
         """Rank resumes against a job description.
 
         Executes the two-tier pipeline:
         1. Parse all resumes and extract entities
-        2. Tier 1: BM25 filter on entity overlap
-        3. Tier 2: Embedding similarity ranking
+        2. Tier 1: BM25 filter on entity overlap (hard exclusion)
+        3. Tier 2: Embedding similarity ranking on survivors
         4. Combine scores and return ranked list
 
         Args:
@@ -296,7 +296,8 @@ class ResumePreScreener:
             extensions: File extensions to include (defaults to standard set).
 
         Returns:
-            List of RankedResume objects sorted by combined_score descending.
+            Tuple of (ranked resumes sorted by combined_score descending,
+            count of resumes excluded by BM25 filter).
 
         """
         doc_specs = discover_documents(
@@ -307,7 +308,7 @@ class ResumePreScreener:
         )
         if not doc_specs:
             logger.warning(f"No documents found in {resumes_folder}")
-            return []
+            return [], 0
 
         logger.info(f"Pre-screening {len(doc_specs)} resumes against JD")
 
@@ -317,9 +318,9 @@ class ResumePreScreener:
         parsed = self._parse_all(doc_specs)
         if not parsed:
             logger.warning("No resumes could be parsed")
-            return []
+            return [], 0
 
-        ranked = self._score_bm25(jd_text, jd_entities, parsed)
+        ranked, bm25_excluded = self._score_bm25(jd_text, jd_entities, parsed)
         ranked = self._score_embeddings(jd_text, ranked)
         ranked = self._combine_scores(ranked)
         ranked.sort(key=lambda r: r.combined_score, reverse=True)
@@ -328,10 +329,10 @@ class ResumePreScreener:
             r.rank = i
 
         logger.info(
-            f"Pre-screening complete: {len(ranked)} ranked, "
-            f"{sum(1 for r in ranked if r.passed_bm25_filter)} passed BM25 filter"
+            f"Pre-screening complete: {len(ranked)} ranked "
+            f"({bm25_excluded} excluded by BM25 filter)"
         )
-        return ranked
+        return ranked, bm25_excluded
 
     def filter_to_top_k(
         self,
@@ -406,22 +407,31 @@ class ResumePreScreener:
         self,
         ranked: list[RankedResume],
         top_k: int,
+        total_discovered: int,
+        bm25_excluded: int,
     ) -> dict[str, Any]:
         """Build a pre-screening report dictionary.
 
         Args:
-            ranked: Full ranked list.
+            ranked: Ranked list (BM25-excluded resumes already removed).
             top_k: Number of candidates that will proceed.
+            total_discovered: Total resumes discovered before any filtering.
+            bm25_excluded: Count of resumes excluded by BM25 filter.
 
         Returns:
             Dict with summary statistics and per-resume details.
 
         """
         selected = self.filter_to_top_k(ranked, top_k)
+        top_k_excluded = max(0, len(ranked) - len(selected))
         return {
-            "total_candidates": len(ranked),
-            "bm25_filtered": sum(1 for r in ranked if not r.passed_bm25_filter),
+            "total_discovered": total_discovered,
+            "bm25_excluded": bm25_excluded,
+            "after_bm25": len(ranked),
+            "embedding_excluded": 0,
             "top_k_selected": len(selected),
+            "top_k_excluded": top_k_excluded,
+            "evaluated_by_llm": len(selected),
             "score_statistics": {
                 "min_combined": min((r.combined_score for r in ranked), default=0.0),
                 "max_combined": max((r.combined_score for r in ranked), default=0.0),
@@ -486,8 +496,11 @@ class ResumePreScreener:
         jd_text: str,
         jd_entities: set[str],
         parsed: list[tuple[DocumentSpec, str]],
-    ) -> list[RankedResume]:
+    ) -> tuple[list[RankedResume], int]:
         """Apply Tier 1 BM25 scoring on entity overlap.
+
+        Resumes that fail the BM25 filter (below minimum score or overlap
+        ratio) are excluded from the returned list entirely.
 
         Args:
             jd_text: Job description text (used as BM25 query).
@@ -495,12 +508,13 @@ class ResumePreScreener:
             parsed: (spec, text) pairs for each resume.
 
         Returns:
-            List of RankedResume with BM25 scores populated.
+            Tuple of (passing RankedResume list, count of excluded resumes).
 
         """
         from ..RAG.indexing.bm25_index import BM25Index
 
-        results: list[RankedResume] = []
+        passing: list[RankedResume] = []
+        excluded_count = 0
 
         bm25 = BM25Index()
         for spec, text in parsed:
@@ -516,13 +530,15 @@ class ResumePreScreener:
 
             bm25_score = bm25_results.get(ref_name, 0.0)
 
-            passed = True
-            if bm25_score < self._bm25_min_score:
-                passed = False
-            if overlap_ratio < self._bm25_min_overlap_ratio:
-                passed = False
+            if bm25_score < self._bm25_min_score or overlap_ratio < self._bm25_min_overlap_ratio:
+                excluded_count += 1
+                logger.debug(
+                    f"BM25 excluded {ref_name}: score={bm25_score:.2f}, "
+                    f"overlap_ratio={overlap_ratio:.2f}"
+                )
+                continue
 
-            results.append(
+            passing.append(
                 RankedResume(
                     reference_name=ref_name,
                     common_name=spec["common_name"],
@@ -530,11 +546,15 @@ class ResumePreScreener:
                     bm25_score=bm25_score,
                     entity_overlap=len(overlap),
                     entity_overlap_ratio=overlap_ratio,
-                    passed_bm25_filter=passed,
+                    passed_bm25_filter=True,
                 )
             )
 
-        return results
+        logger.info(
+            f"BM25 filter: {len(passing)} passed, {excluded_count} excluded "
+            f"(min_score={self._bm25_min_score}, min_overlap={self._bm25_min_overlap_ratio})"
+        )
+        return passing, excluded_count
 
     def _score_embeddings(
         self,
@@ -543,27 +563,25 @@ class ResumePreScreener:
     ) -> list[RankedResume]:
         """Apply Tier 2 embedding similarity scoring.
 
-        Only resumes that passed the BM25 filter are embedded. Those that
-        failed get an embedding_score of 0.0.
+        All resumes in the list have already passed the BM25 hard filter.
+        Computes embedding cosine similarity between JD and each resume.
 
         Args:
             jd_text: Job description text.
-            resumes: RankedResume list with BM25 scores populated.
+            resumes: RankedResume list with BM25 scores populated (BM25-excluded
+                resumes already removed).
 
         Returns:
             Same list with embedding_score populated.
 
         """
-        passing = [r for r in resumes if r.passed_bm25_filter]
-
-        if not passing:
-            logger.warning("No resumes passed BM25 filter, embedding all as fallback")
-            passing = resumes
+        if not resumes:
+            return resumes
 
         jd_embedding = self._embeddings.embed_single(jd_text)
 
         batch_texts = []
-        for r in passing:
+        for r in resumes:
             try:
                 content = self._doc_processor.get_document_content(
                     r.file_path, r.reference_name, r.common_name
@@ -575,7 +593,7 @@ class ResumePreScreener:
 
         if batch_texts:
             resume_embeddings = self._embed_batch(batch_texts)
-            for r, emb in zip(passing, resume_embeddings):
+            for r, emb in zip(resumes, resume_embeddings):
                 r.embedding_score = FFEmbeddings.cosine_similarity(jd_embedding, emb)
 
         return resumes
@@ -618,8 +636,8 @@ class ResumePreScreener:
     def _combine_scores(self, resumes: list[RankedResume]) -> list[RankedResume]:
         """Compute combined score from BM25 and embedding scores.
 
-        Uses configured weights. Resumes that failed BM25 filter get
-        their BM25 contribution zeroed but still receive embedding scores.
+        Uses configured weights to produce a single combined score for each
+        resume. All resumes in the list have passed the BM25 hard filter.
 
         Args:
             resumes: RankedResume list with both scores populated.
@@ -628,6 +646,9 @@ class ResumePreScreener:
             Same list with combined_score populated.
 
         """
+        if not resumes:
+            return resumes
+
         bm25_scores = [r.bm25_score for r in resumes]
         emb_scores = [r.embedding_score for r in resumes]
 

--- a/src/orchestrator/pre_screener.py
+++ b/src/orchestrator/pre_screener.py
@@ -1,0 +1,578 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+"""Embedding-based resume pre-screener for cost reduction.
+
+Ranks resumes against a job description using a two-tier pipeline:
+  Tier 1 — BM25 keyword filtering on extracted named entities
+  Tier 2 — Dense embedding cosine similarity ranking
+
+Returns a ranked list of candidates so that only the top-K need to be
+sent through the full LLM evaluation pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..config import get_config
+from ..RAG.FFEmbeddings import FFEmbeddings
+from .discovery import DocumentSpec, discover_documents
+from .document_processor import DocumentProcessor
+
+logger = logging.getLogger(__name__)
+
+_ENTITY_RE = re.compile(
+    r"\b(?:"
+    r"[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+"  # multi-word: "Google Cloud Platform"
+    r"|[A-Z][a-z]+[A-Z][A-Za-z]*"  # camelCase: "BigQuery", "JavaScript"
+    r"|[A-Z]{2,}"  # acronyms: "GCP", "SQL"
+    r"|[A-Z][a-z]+"  # single capitalized: "Python"
+    r")\b"
+)
+
+_STOPWORDS = frozenset(
+    {
+        "The",
+        "And",
+        "With",
+        "For",
+        "From",
+        "This",
+        "That",
+        "Not",
+        "Are",
+        "Was",
+        "Has",
+        "Had",
+        "Been",
+        "Being",
+        "Will",
+        "Would",
+        "Could",
+        "Should",
+        "May",
+        "Might",
+        "Must",
+        "Shall",
+        "Can",
+        "Does",
+        "Did",
+        "But",
+        "Our",
+        "Your",
+        "Their",
+        "His",
+        "Her",
+        "Its",
+        "Who",
+        "What",
+        "When",
+        "Where",
+        "How",
+        "Why",
+        "All",
+        "Each",
+        "Every",
+        "Both",
+        "Few",
+        "More",
+        "Most",
+        "Other",
+        "Some",
+        "Such",
+        "Than",
+        "Too",
+        "Very",
+        "Just",
+        "Also",
+        "About",
+        "After",
+        "Before",
+        "Between",
+        "Into",
+        "Through",
+        "During",
+        "Here",
+        "There",
+        "Which",
+        "While",
+        "Then",
+        "Once",
+        "We",
+        "They",
+        "Knowledge",
+        "Years",
+        "Year",
+        "Experience",
+        "Work",
+        "Working",
+        "Including",
+        "Include",
+        "Based",
+        "Using",
+        "Use",
+        "Strong",
+        "Excellent",
+        "Good",
+        "Ability",
+        "Looking",
+        "Required",
+        "Preferred",
+    }
+)
+
+
+@dataclass
+class RankedResume:
+    """A resume with its pre-screening scores and metadata."""
+
+    reference_name: str
+    common_name: str
+    file_path: str
+    bm25_score: float = 0.0
+    embedding_score: float = 0.0
+    combined_score: float = 0.0
+    entity_overlap: int = 0
+    entity_overlap_ratio: float = 0.0
+    passed_bm25_filter: bool = True
+    rank: int = 0
+
+
+def extract_entities(text: str) -> set[str]:
+    """Extract capitalized named entities from text.
+
+    Identifies multi-word capitalized sequences (e.g., "Google Cloud Platform"),
+    acronyms (e.g., "GCP", "SQL"), and single capitalized terms (e.g., "Python").
+    Common English stopwords and generic resume terms are filtered out.
+
+    Args:
+        text: Input text to extract entities from.
+
+    Returns:
+        Set of extracted entity strings.
+
+    """
+    raw = set(_ENTITY_RE.findall(text))
+    return raw - _STOPWORDS
+
+
+class ResumePreScreener:
+    """Two-tier resume ranking pipeline.
+
+    Tier 1 uses BM25 scoring on named entities extracted from the JD to
+    quickly filter out resumes with negligible keyword overlap. Tier 2
+    computes dense embedding similarity between the JD and each surviving
+    resume for precise semantic ranking.
+
+    Args:
+        embedding_model: LiteLLM model string (e.g., ``"mistral/mistral-embed"``).
+        cache_dir: Directory for parsed document cache.
+        bm25_min_score: Minimum BM25 score to pass tier 1 filter.
+        bm25_min_overlap_ratio: Minimum fraction of JD entities that must appear.
+        bm25_weight: Weight for BM25 score in combined ranking (0-1).
+        embedding_weight: Weight for embedding score in combined ranking (0-1).
+        embedding_cache_size: LRU cache size for embedding model.
+
+    """
+
+    def __init__(
+        self,
+        embedding_model: str = "mistral/mistral-embed",
+        cache_dir: str | None = None,
+        bm25_min_score: float = 0.0,
+        bm25_min_overlap_ratio: float = 0.0,
+        bm25_weight: float = 0.3,
+        embedding_weight: float = 0.7,
+        embedding_cache_size: int = 512,
+    ) -> None:
+        config = get_config()
+        self._cache_dir = cache_dir or config.paths.ffai_data
+        self._bm25_min_score = bm25_min_score
+        self._bm25_min_overlap_ratio = bm25_min_overlap_ratio
+        self._bm25_weight = bm25_weight
+        self._embedding_weight = embedding_weight
+
+        self._embeddings = FFEmbeddings(
+            model=embedding_model,
+            cache_enabled=True,
+            cache_size=embedding_cache_size,
+        )
+        self._doc_processor = DocumentProcessor(
+            cache_dir=self._cache_dir,
+        )
+
+        logger.info(
+            f"ResumePreScreener initialized: model={embedding_model}, "
+            f"bm25_weight={bm25_weight}, embedding_weight={embedding_weight}"
+        )
+
+    def rank_resumes(
+        self,
+        jd_text: str,
+        resumes_folder: str | Path,
+        extensions: set[str] | None = None,
+    ) -> list[RankedResume]:
+        """Rank resumes against a job description.
+
+        Executes the two-tier pipeline:
+        1. Parse all resumes and extract entities
+        2. Tier 1: BM25 filter on entity overlap
+        3. Tier 2: Embedding similarity ranking
+        4. Combine scores and return ranked list
+
+        Args:
+            jd_text: Full text of the job description.
+            resumes_folder: Path to folder containing resume files.
+            extensions: File extensions to include (defaults to standard set).
+
+        Returns:
+            List of RankedResume objects sorted by combined_score descending.
+
+        """
+        doc_specs = discover_documents(
+            resumes_folder,
+            extensions=extensions,
+            absolute_paths=True,
+            tags=["resume"],
+        )
+        if not doc_specs:
+            logger.warning(f"No documents found in {resumes_folder}")
+            return []
+
+        logger.info(f"Pre-screening {len(doc_specs)} resumes against JD")
+
+        jd_entities = extract_entities(jd_text)
+        logger.info(f"Extracted {len(jd_entities)} entities from JD: {sorted(jd_entities)[:20]}")
+
+        parsed = self._parse_all(doc_specs)
+        if not parsed:
+            logger.warning("No resumes could be parsed")
+            return []
+
+        ranked = self._score_bm25(jd_text, jd_entities, parsed)
+        ranked = self._score_embeddings(jd_text, ranked)
+        ranked = self._combine_scores(ranked)
+        ranked.sort(key=lambda r: r.combined_score, reverse=True)
+
+        for i, r in enumerate(ranked, start=1):
+            r.rank = i
+
+        logger.info(
+            f"Pre-screening complete: {len(ranked)} ranked, "
+            f"{sum(1 for r in ranked if r.passed_bm25_filter)} passed BM25 filter"
+        )
+        return ranked
+
+    def filter_to_top_k(
+        self,
+        ranked: list[RankedResume],
+        top_k: int,
+    ) -> list[RankedResume]:
+        """Return only the top-K ranked resumes.
+
+        Args:
+            ranked: Full ranked list from ``rank_resumes()``.
+            top_k: Number of top candidates to return.
+
+        Returns:
+            Top-K RankedResume objects.
+
+        """
+        return ranked[:top_k]
+
+    def build_data_rows(
+        self,
+        ranked: list[RankedResume],
+    ) -> list[dict[str, Any]]:
+        """Build data rows suitable for manifest data.yaml from ranked resumes.
+
+        Args:
+            ranked: Ranked resume list (typically already filtered to top-K).
+
+        Returns:
+            List of dicts with id, batch_name, candidate_name, _documents.
+
+        """
+        rows: list[dict[str, Any]] = []
+        for idx, resume in enumerate(ranked, start=1):
+            rows.append(
+                {
+                    "id": idx,
+                    "batch_name": resume.reference_name,
+                    "candidate_name": resume.common_name,
+                    "_documents": f'["{resume.reference_name}"]',
+                }
+            )
+        return rows
+
+    def build_document_specs(
+        self,
+        ranked: list[RankedResume],
+    ) -> list[DocumentSpec]:
+        """Build document specs for manifest documents.yaml from ranked resumes.
+
+        Args:
+            ranked: Ranked resume list (typically already filtered to top-K).
+
+        Returns:
+            List of DocumentSpec dicts for manifest documents.yaml.
+
+        """
+        specs: list[DocumentSpec] = []
+        for resume in ranked:
+            specs.append(
+                {
+                    "reference_name": resume.reference_name,
+                    "common_name": resume.common_name,
+                    "file_path": resume.file_path,
+                    "tags": "resume",
+                    "chunking_strategy": "",
+                    "notes": (f"pre-screen rank={resume.rank}, score={resume.combined_score:.4f}"),
+                }
+            )
+        return specs
+
+    def build_report(
+        self,
+        ranked: list[RankedResume],
+        top_k: int,
+    ) -> dict[str, Any]:
+        """Build a pre-screening report dictionary.
+
+        Args:
+            ranked: Full ranked list.
+            top_k: Number of candidates that will proceed.
+
+        Returns:
+            Dict with summary statistics and per-resume details.
+
+        """
+        selected = self.filter_to_top_k(ranked, top_k)
+        return {
+            "total_candidates": len(ranked),
+            "bm25_filtered": sum(1 for r in ranked if not r.passed_bm25_filter),
+            "top_k_selected": len(selected),
+            "score_statistics": {
+                "min_combined": min((r.combined_score for r in ranked), default=0.0),
+                "max_combined": max((r.combined_score for r in ranked), default=0.0),
+                "avg_combined": (
+                    sum(r.combined_score for r in ranked) / len(ranked) if ranked else 0.0
+                ),
+            },
+            "selected_candidates": [
+                {
+                    "rank": r.rank,
+                    "reference_name": r.reference_name,
+                    "common_name": r.common_name,
+                    "combined_score": round(r.combined_score, 4),
+                    "embedding_score": round(r.embedding_score, 4),
+                    "bm25_score": round(r.bm25_score, 4),
+                    "entity_overlap": r.entity_overlap,
+                }
+                for r in selected
+            ],
+            "all_candidates": [
+                {
+                    "rank": r.rank,
+                    "reference_name": r.reference_name,
+                    "common_name": r.common_name,
+                    "combined_score": round(r.combined_score, 4),
+                    "passed_bm25": r.passed_bm25_filter,
+                }
+                for r in ranked
+            ],
+        }
+
+    def _parse_all(
+        self,
+        doc_specs: list[DocumentSpec],
+    ) -> list[tuple[DocumentSpec, str]]:
+        """Parse all documents and return (spec, text) pairs.
+
+        Args:
+            doc_specs: Document specifications from discovery.
+
+        Returns:
+            List of (DocumentSpec, text_content) tuples.
+
+        """
+        parsed: list[tuple[DocumentSpec, str]] = []
+        for spec in doc_specs:
+            file_path = spec["file_path"]
+            ref_name = spec["reference_name"]
+            common_name = spec["common_name"]
+            try:
+                content = self._doc_processor.get_document_content(file_path, ref_name, common_name)
+                if content.strip():
+                    parsed.append((spec, content))
+                else:
+                    logger.warning(f"Empty content for {ref_name}, skipping")
+            except Exception as e:
+                logger.warning(f"Failed to parse {ref_name}: {e}")
+        return parsed
+
+    def _score_bm25(
+        self,
+        jd_text: str,
+        jd_entities: set[str],
+        parsed: list[tuple[DocumentSpec, str]],
+    ) -> list[RankedResume]:
+        """Apply Tier 1 BM25 scoring on entity overlap.
+
+        Args:
+            jd_text: Job description text (used as BM25 query).
+            jd_entities: Entities extracted from the JD.
+            parsed: (spec, text) pairs for each resume.
+
+        Returns:
+            List of RankedResume with BM25 scores populated.
+
+        """
+        from ..RAG.indexing.bm25_index import BM25Index
+
+        results: list[RankedResume] = []
+
+        bm25 = BM25Index()
+        for spec, text in parsed:
+            bm25.add_document(spec["reference_name"], text)
+
+        bm25_results = {r["id"]: r["score"] for r in bm25.search(jd_text, n_results=len(parsed))}
+
+        for spec, text in parsed:
+            ref_name = spec["reference_name"]
+            resume_entities = extract_entities(text)
+            overlap = jd_entities & resume_entities
+            overlap_ratio = len(overlap) / len(jd_entities) if jd_entities else 0.0
+
+            bm25_score = bm25_results.get(ref_name, 0.0)
+
+            passed = True
+            if bm25_score < self._bm25_min_score:
+                passed = False
+            if overlap_ratio < self._bm25_min_overlap_ratio:
+                passed = False
+
+            results.append(
+                RankedResume(
+                    reference_name=ref_name,
+                    common_name=spec["common_name"],
+                    file_path=spec["file_path"],
+                    bm25_score=bm25_score,
+                    entity_overlap=len(overlap),
+                    entity_overlap_ratio=overlap_ratio,
+                    passed_bm25_filter=passed,
+                )
+            )
+
+        return results
+
+    def _score_embeddings(
+        self,
+        jd_text: str,
+        resumes: list[RankedResume],
+    ) -> list[RankedResume]:
+        """Apply Tier 2 embedding similarity scoring.
+
+        Only resumes that passed the BM25 filter are embedded. Those that
+        failed get an embedding_score of 0.0.
+
+        Args:
+            jd_text: Job description text.
+            resumes: RankedResume list with BM25 scores populated.
+
+        Returns:
+            Same list with embedding_score populated.
+
+        """
+        passing = [r for r in resumes if r.passed_bm25_filter]
+
+        if not passing:
+            logger.warning("No resumes passed BM25 filter, embedding all as fallback")
+            passing = resumes
+
+        jd_embedding = self._embeddings.embed_single(jd_text)
+
+        batch_texts = []
+        for r in passing:
+            try:
+                content = self._doc_processor.get_document_content(
+                    r.file_path, r.reference_name, r.common_name
+                )
+                batch_texts.append(content)
+            except Exception as e:
+                logger.warning(f"Failed to read {r.reference_name} for embedding: {e}")
+                batch_texts.append("")
+
+        if batch_texts:
+            resume_embeddings = self._embed_batch(batch_texts)
+            for r, emb in zip(passing, resume_embeddings):
+                r.embedding_score = FFEmbeddings.cosine_similarity(jd_embedding, emb)
+
+        return resumes
+
+    def _embed_batch(
+        self,
+        texts: list[str],
+        batch_size: int = 20,
+        max_chars: int = 8000,
+    ) -> list[list[float]]:
+        """Embed texts in API-safe batches.
+
+        Splits texts into batches to avoid API token limits, and truncates
+        individual texts to stay within per-item limits.
+
+        Args:
+            texts: List of text strings to embed.
+            batch_size: Number of texts per API call.
+            max_chars: Maximum characters per text (truncated if longer).
+
+        Returns:
+            List of embedding vectors in the same order as input.
+
+        """
+        truncated = [t[:max_chars] if len(t) > max_chars else t for t in texts]
+
+        all_embeddings: list[list[float]] = []
+        for i in range(0, len(truncated), batch_size):
+            chunk = truncated[i : i + batch_size]
+            logger.info(
+                f"Embedding batch {i // batch_size + 1}/"
+                f"{(len(truncated) + batch_size - 1) // batch_size} "
+                f"({len(chunk)} texts)"
+            )
+            batch_embs = self._embeddings.embed(chunk)
+            all_embeddings.extend(batch_embs)
+
+        return all_embeddings
+
+    def _combine_scores(self, resumes: list[RankedResume]) -> list[RankedResume]:
+        """Compute combined score from BM25 and embedding scores.
+
+        Uses configured weights. Resumes that failed BM25 filter get
+        their BM25 contribution zeroed but still receive embedding scores.
+
+        Args:
+            resumes: RankedResume list with both scores populated.
+
+        Returns:
+            Same list with combined_score populated.
+
+        """
+        bm25_scores = [r.bm25_score for r in resumes]
+        emb_scores = [r.embedding_score for r in resumes]
+
+        max_bm25 = max(bm25_scores) if bm25_scores and max(bm25_scores) > 0 else 1.0
+        max_emb = max(emb_scores) if emb_scores and max(emb_scores) > 0 else 1.0
+
+        for r in resumes:
+            norm_bm25 = r.bm25_score / max_bm25
+            norm_emb = r.embedding_score / max_emb
+            r.combined_score = self._bm25_weight * norm_bm25 + self._embedding_weight * norm_emb
+
+        return resumes

--- a/tests/test_pre_screener.py
+++ b/tests/test_pre_screener.py
@@ -85,6 +85,34 @@ class TestExtractEntities:
         assert "We" not in result
         assert "Knowledge" not in result
 
+    def test_technology_names_with_symbols(self):
+        from src.orchestrator.pre_screener import extract_entities
+
+        result = extract_entities("Proficient in C++, C#, .NET, and Node.js")
+        assert "C++" in result
+        assert "C#" in result
+        assert ".NET" in result
+        assert "Node.js" in result
+
+    def test_resume_noise_words_filtered(self):
+        from src.orchestrator.pre_screener import extract_entities
+
+        text = "Senior Development Engineering Manager at Company University"
+        result = extract_entities(text)
+        assert "Senior" not in result
+        assert "Development" not in result
+        assert "Engineering" not in result
+        assert "Manager" not in result
+        assert "Company" not in result
+        assert "University" not in result
+
+    def test_months_filtered(self):
+        from src.orchestrator.pre_screener import extract_entities
+
+        result = extract_entities("Started January 2020, promoted March 2021")
+        assert "January" not in result
+        assert "March" not in result
+
 
 class TestRankedResume:
     """Tests for RankedResume dataclass."""

--- a/tests/test_pre_screener.py
+++ b/tests/test_pre_screener.py
@@ -267,7 +267,7 @@ class TestResumePreScreenerFiltering:
                 bm25_score=2.0,
                 entity_overlap=3,
                 entity_overlap_ratio=0.15,
-                passed_bm25_filter=False,
+                passed_bm25_filter=True,
                 rank=2,
             ),
         ]
@@ -277,10 +277,13 @@ class TestResumePreScreenerFiltering:
             with patch("src.orchestrator.pre_screener.DocumentProcessor"):
                 screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
 
-        report = screener.build_report(resumes, top_k=1)
-        assert report["total_candidates"] == 2
-        assert report["bm25_filtered"] == 1
+        report = screener.build_report(resumes, top_k=1, total_discovered=3, bm25_excluded=1)
+        assert report["total_discovered"] == 3
+        assert report["bm25_excluded"] == 1
+        assert report["after_bm25"] == 2
         assert report["top_k_selected"] == 1
+        assert report["top_k_excluded"] == 1
+        assert report["evaluated_by_llm"] == 1
         assert len(report["selected_candidates"]) == 1
         assert report["selected_candidates"][0]["reference_name"] == "alice"
         assert len(report["all_candidates"]) == 2
@@ -294,8 +297,8 @@ class TestResumePreScreenerFiltering:
             with patch("src.orchestrator.pre_screener.DocumentProcessor"):
                 screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
 
-        report = screener.build_report([], top_k=5)
-        assert report["total_candidates"] == 0
+        report = screener.build_report([], top_k=5, total_discovered=0, bm25_excluded=0)
+        assert report["total_discovered"] == 0
         assert report["selected_candidates"] == []
 
 
@@ -351,19 +354,19 @@ class TestResumePreScreenerRanking:
 
     def test_rank_resumes_returns_all(self, resume_folder):
         screener = self._create_screener()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, bm25_excluded = screener.rank_resumes(self.JD_TEXT, resume_folder)
         assert len(ranked) == 3
         assert all(isinstance(r, RankedResume) for r in ranked)
 
     def test_rank_resumes_assigns_ranks(self, resume_folder):
         screener = self._create_screener()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
         ranks = [r.rank for r in ranked]
         assert sorted(ranks) == [1, 2, 3]
 
     def test_rank_resumes_populates_entity_overlap(self, resume_folder):
         screener = self._create_screener()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
 
         alice = next(r for r in ranked if r.reference_name == "alice_strong")
         assert alice.entity_overlap > 0
@@ -373,19 +376,19 @@ class TestResumePreScreenerRanking:
 
     def test_rank_resumes_populates_combined_score(self, resume_folder):
         screener = self._create_screener()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
         for r in ranked:
             assert r.combined_score >= 0.0
 
     def test_filter_after_ranking(self, resume_folder):
         screener = self._create_screener()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
         top2 = screener.filter_to_top_k(ranked, 2)
         assert len(top2) == 2
 
     def test_bm25_scoring_differentiates_resumes(self, resume_folder):
         screener = self._create_screener()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
 
         alice = next(r for r in ranked if r.reference_name == "alice_strong")
         carol = next(r for r in ranked if r.reference_name == "carol_weak")
@@ -395,17 +398,52 @@ class TestResumePreScreenerRanking:
         folder = tmp_path / "empty"
         folder.mkdir()
         screener = self._create_screener()
-        ranked = screener.rank_resumes(self.JD_TEXT, folder)
+        ranked, bm25_excluded = screener.rank_resumes(self.JD_TEXT, folder)
         assert ranked == []
+        assert bm25_excluded == 0
 
     def test_build_data_rows_after_ranking(self, resume_folder):
         screener = self._create_screener()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
         top2 = screener.filter_to_top_k(ranked, 2)
         rows = screener.build_data_rows(top2)
         assert len(rows) == 2
         assert all("batch_name" in r for r in rows)
         assert all("_documents" in r for r in rows)
+
+    def test_all_returned_resumes_passed_bm25(self, resume_folder):
+        screener = self._create_screener()
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        assert all(r.passed_bm25_filter for r in ranked)
+
+    def test_bm25_hard_exclusion_with_strict_threshold(self, resume_folder):
+        mock_emb = MagicMock()
+        mock_emb.embed_single.return_value = [0.5] * 8
+        mock_emb.embed.return_value = [[0.5] * 8] * 10
+        mock_emb.cosine_similarity = MagicMock(side_effect=lambda a, b: 0.9)
+
+        def _read_file(fp, rn, cn):
+            return Path(fp).read_text(encoding="utf-8")
+
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_emb):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor") as MockDP:
+                mock_dp = MagicMock()
+                mock_dp.get_document_content.side_effect = _read_file
+                MockDP.return_value = mock_dp
+                screener = ResumePreScreener(
+                    embedding_model="mistral/mistral-embed",
+                    bm25_min_overlap_ratio=0.3,
+                )
+
+        screener._embeddings = mock_emb
+        screener._doc_processor = mock_dp
+
+        ranked, bm25_excluded = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        assert bm25_excluded > 0
+        assert len(ranked) + bm25_excluded == 3
+        assert all(r.passed_bm25_filter for r in ranked)
+        for r in ranked:
+            assert r.entity_overlap_ratio >= 0.3
 
 
 class TestResumePreScreenerIntegration:
@@ -477,17 +515,17 @@ class TestResumePreScreenerIntegration:
 
     def test_alice_ranks_highest(self, resume_folder):
         screener = self._create_screener_with_realistic_embeddings()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
         assert ranked[0].reference_name == "alice"
 
     def test_carol_ranks_lowest(self, resume_folder):
         screener = self._create_screener_with_realistic_embeddings()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
         assert ranked[-1].reference_name == "carol"
 
     def test_entity_overlap_counts(self, resume_folder):
         screener = self._create_screener_with_realistic_embeddings()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
 
         alice = next(r for r in ranked if r.reference_name == "alice")
         carol = next(r for r in ranked if r.reference_name == "carol")
@@ -496,18 +534,18 @@ class TestResumePreScreenerIntegration:
 
     def test_full_pipeline_report(self, resume_folder):
         screener = self._create_screener_with_realistic_embeddings()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, bm25_excluded = screener.rank_resumes(self.JD_TEXT, resume_folder)
         top2 = screener.filter_to_top_k(ranked, 2)
-        report = screener.build_report(ranked, 2)
+        report = screener.build_report(ranked, 2, total_discovered=3, bm25_excluded=bm25_excluded)
 
-        assert report["total_candidates"] == 3
+        assert report["total_discovered"] == 3
         assert report["top_k_selected"] == 2
         assert len(report["selected_candidates"]) == 2
         assert report["selected_candidates"][0]["common_name"] == "alice"
 
     def test_combined_score_monotonic_with_relevance(self, resume_folder):
         screener = self._create_screener_with_realistic_embeddings()
-        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranked, _ = screener.rank_resumes(self.JD_TEXT, resume_folder)
 
         scores = [r.combined_score for r in ranked]
         for i in range(len(scores) - 1):
@@ -524,10 +562,10 @@ class TestPreScreeningConfig:
 
         config = get_config()
         assert config.pre_screening.enabled is True
-        assert config.pre_screening.top_k == 20
         assert config.pre_screening.bm25_weight == 0.3
         assert config.pre_screening.embedding_weight == 0.7
         assert config.pre_screening.embedding_model == "mistral/mistral-embed"
+        assert config.pre_screening.bm25_min_overlap_ratio == 0.05
 
     def test_config_embedding_cache_size(self):
         from src.config import get_config

--- a/tests/test_pre_screener.py
+++ b/tests/test_pre_screener.py
@@ -1,0 +1,508 @@
+# Copyright (c) 2025 Antonio Quinonez / Far Finer LLC
+# SPDX-License-Identifier: MIT
+# Contact: antquinonez@farfiner.com
+
+"""Tests for src/orchestrator/pre_screener.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.orchestrator.pre_screener import (
+    RankedResume,
+    ResumePreScreener,
+    extract_entities,
+)
+
+
+class TestExtractEntities:
+    """Tests for extract_entities function."""
+
+    def test_single_capitalized_word(self):
+        result = extract_entities("Experience with Python and Java")
+        assert "Python" in result
+        assert "Java" in result
+
+    def test_multi_word_entity(self):
+        result = extract_entities("Experience with Google Cloud Platform")
+        assert "Google Cloud Platform" in result
+
+    def test_acronyms(self):
+        result = extract_entities("Skills in SQL and GCP and AWS")
+        assert "SQL" in result
+        assert "GCP" in result
+        assert "AWS" in result
+
+    def test_stopwords_filtered(self):
+        result = extract_entities("The candidate has Strong experience")
+        assert "The" not in result
+        assert "Strong" not in result
+
+    def test_lowercase_ignored(self):
+        result = extract_entities("experience with python")
+        assert "python" not in result
+        assert "experience" not in result
+
+    def test_empty_string(self):
+        assert extract_entities("") == set()
+
+    def test_no_capitalized_words(self):
+        assert extract_entities("this is all lowercase text") == set()
+
+    def test_mixed_entities(self):
+        text = "Apache Spark on Google Cloud with Python, SQL, and Airflow"
+        result = extract_entities(text)
+        assert "Apache Spark" in result
+        assert "Google Cloud" in result
+        assert "Python" in result
+        assert "SQL" in result
+        assert "Airflow" in result
+
+    def test_common_resume_terms_filtered(self):
+        text = "Years of Experience Working with Python"
+        result = extract_entities(text)
+        assert "Years" not in result
+        assert "Experience" not in result
+        assert "Working" not in result
+        assert "Python" in result
+
+    def test_jd_typical_content(self):
+        text = (
+            "We are looking for a Data Engineer with experience in "
+            "Apache Spark, BigQuery, and Python. Knowledge of Docker and "
+            "Kubernetes is a plus. Google Cloud Platform experience preferred."
+        )
+        result = extract_entities(text)
+        assert "Apache Spark" in result
+        assert "BigQuery" in result
+        assert "Python" in result
+        assert "Docker" in result
+        assert "Kubernetes" in result
+        assert "Google Cloud Platform" in result
+        assert "We" not in result
+        assert "Knowledge" not in result
+
+
+class TestRankedResume:
+    """Tests for RankedResume dataclass."""
+
+    def test_default_values(self):
+        r = RankedResume(
+            reference_name="alice_chen",
+            common_name="Alice Chen",
+            file_path="/path/to/alice.pdf",
+        )
+        assert r.bm25_score == 0.0
+        assert r.embedding_score == 0.0
+        assert r.combined_score == 0.0
+        assert r.entity_overlap == 0
+        assert r.passed_bm25_filter is True
+        assert r.rank == 0
+
+    def test_with_scores(self):
+        r = RankedResume(
+            reference_name="alice",
+            common_name="Alice",
+            file_path="/alice.pdf",
+            bm25_score=12.5,
+            embedding_score=0.85,
+            combined_score=0.72,
+            entity_overlap=15,
+            rank=1,
+        )
+        assert r.bm25_score == 12.5
+        assert r.embedding_score == 0.85
+        assert r.rank == 1
+
+
+class TestResumePreScreenerFiltering:
+    """Tests for filtering and ranking methods that don't require API calls."""
+
+    def _make_resume(self, name: str, score: float = 0.5) -> RankedResume:
+        return RankedResume(
+            reference_name=name.lower().replace(" ", "_"),
+            common_name=name,
+            file_path=f"/path/{name}.pdf",
+            combined_score=score,
+            embedding_score=score * 0.8,
+            bm25_score=score * 10,
+        )
+
+    def test_filter_to_top_k(self):
+        resumes = [
+            self._make_resume("Alice", 0.9),
+            self._make_resume("Bob", 0.7),
+            self._make_resume("Carol", 0.5),
+            self._make_resume("Dave", 0.3),
+        ]
+        mock_embeddings = MagicMock()
+        mock_embeddings.embed.return_value = [[0.1] * 10]
+        mock_embeddings.embed_single.return_value = [0.1] * 10
+
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_embeddings):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor"):
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        result = screener.filter_to_top_k(resumes, 2)
+        assert len(result) == 2
+        assert result[0].common_name == "Alice"
+        assert result[1].common_name == "Bob"
+
+    def test_filter_top_k_larger_than_list(self):
+        resumes = [self._make_resume("Alice", 0.9)]
+        mock_embeddings = MagicMock()
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_embeddings):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor"):
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        result = screener.filter_to_top_k(resumes, 10)
+        assert len(result) == 1
+
+    def test_filter_top_k_zero(self):
+        resumes = [self._make_resume("Alice", 0.9)]
+        mock_embeddings = MagicMock()
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_embeddings):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor"):
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        result = screener.filter_to_top_k(resumes, 0)
+        assert len(result) == 0
+
+    def test_build_data_rows(self):
+        resumes = [
+            self._make_resume("Alice Chen", 0.9),
+            self._make_resume("Bob Martinez", 0.7),
+        ]
+        resumes[0].rank = 1
+        resumes[1].rank = 2
+
+        mock_embeddings = MagicMock()
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_embeddings):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor"):
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        rows = screener.build_data_rows(resumes)
+        assert len(rows) == 2
+        assert rows[0]["id"] == 1
+        assert rows[0]["batch_name"] == "alice_chen"
+        assert rows[0]["candidate_name"] == "Alice Chen"
+        assert rows[0]["_documents"] == '["alice_chen"]'
+        assert rows[1]["id"] == 2
+
+    def test_build_document_specs(self):
+        resumes = [
+            RankedResume(
+                reference_name="alice_chen",
+                common_name="Alice Chen",
+                file_path="/path/alice.pdf",
+                rank=1,
+                combined_score=0.9,
+            ),
+        ]
+
+        mock_embeddings = MagicMock()
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_embeddings):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor"):
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        specs = screener.build_document_specs(resumes)
+        assert len(specs) == 1
+        assert specs[0]["reference_name"] == "alice_chen"
+        assert specs[0]["common_name"] == "Alice Chen"
+        assert specs[0]["file_path"] == "/path/alice.pdf"
+        assert "resume" in specs[0]["tags"]
+        assert "rank=1" in specs[0]["notes"]
+
+    def test_build_report(self):
+        resumes = [
+            RankedResume(
+                reference_name="alice",
+                common_name="Alice",
+                file_path="/alice.pdf",
+                combined_score=0.9,
+                embedding_score=0.85,
+                bm25_score=12.0,
+                entity_overlap=15,
+                entity_overlap_ratio=0.75,
+                passed_bm25_filter=True,
+                rank=1,
+            ),
+            RankedResume(
+                reference_name="bob",
+                common_name="Bob",
+                file_path="/bob.pdf",
+                combined_score=0.3,
+                embedding_score=0.2,
+                bm25_score=2.0,
+                entity_overlap=3,
+                entity_overlap_ratio=0.15,
+                passed_bm25_filter=False,
+                rank=2,
+            ),
+        ]
+
+        mock_embeddings = MagicMock()
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_embeddings):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor"):
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        report = screener.build_report(resumes, top_k=1)
+        assert report["total_candidates"] == 2
+        assert report["bm25_filtered"] == 1
+        assert report["top_k_selected"] == 1
+        assert len(report["selected_candidates"]) == 1
+        assert report["selected_candidates"][0]["reference_name"] == "alice"
+        assert len(report["all_candidates"]) == 2
+        assert "min_combined" in report["score_statistics"]
+        assert "max_combined" in report["score_statistics"]
+        assert "avg_combined" in report["score_statistics"]
+
+    def test_build_report_empty(self):
+        mock_embeddings = MagicMock()
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_embeddings):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor"):
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        report = screener.build_report([], top_k=5)
+        assert report["total_candidates"] == 0
+        assert report["selected_candidates"] == []
+
+
+class TestResumePreScreenerRanking:
+    """Tests for the full ranking pipeline with mocked embeddings."""
+
+    JD_TEXT = (
+        "Senior Data Engineer\n\n"
+        "We need someone with Apache Spark, BigQuery, Python, and SQL experience. "
+        "Google Cloud Platform and Docker knowledge required. "
+        "Kubernetes and Airflow are a plus."
+    )
+
+    @pytest.fixture
+    def resume_folder(self, tmp_path: Path) -> Path:
+        folder = tmp_path / "resumes"
+        folder.mkdir()
+        (folder / "alice_strong.txt").write_text(
+            "Alice Chen\nSenior Data Engineer with 5 years experience.\n"
+            "Skills: Apache Spark, BigQuery, Python, SQL, Docker.\n"
+            "Google Cloud Platform certified. Kubernetes deployment experience."
+        )
+        (folder / "bob_medium.txt").write_text(
+            "Bob Martinez\nBackend Developer.\nSkills: Python, SQL, Docker.\nSome cloud experience."
+        )
+        (folder / "carol_weak.txt").write_text(
+            "Carol Johnson\nJunior Frontend Developer.\n"
+            "Skills: HTML, CSS, JavaScript.\n"
+            "Looking for opportunities."
+        )
+        return folder
+
+    def _create_screener(self):
+        mock_emb = MagicMock()
+        dim = 8
+        mock_emb.embed_single.return_value = [0.5] * dim
+        mock_emb.embed.return_value = [[0.5] * dim] * 10
+        mock_emb.cosine_similarity = MagicMock(side_effect=lambda a, b: 0.9)
+
+        def _read_file(fp, rn, cn):
+            return Path(fp).read_text(encoding="utf-8")
+
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_emb):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor") as MockDP:
+                mock_dp = MagicMock()
+                mock_dp.get_document_content.side_effect = _read_file
+                MockDP.return_value = mock_dp
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        screener._embeddings = mock_emb
+        screener._doc_processor = mock_dp
+        return screener
+
+    def test_rank_resumes_returns_all(self, resume_folder):
+        screener = self._create_screener()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        assert len(ranked) == 3
+        assert all(isinstance(r, RankedResume) for r in ranked)
+
+    def test_rank_resumes_assigns_ranks(self, resume_folder):
+        screener = self._create_screener()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        ranks = [r.rank for r in ranked]
+        assert sorted(ranks) == [1, 2, 3]
+
+    def test_rank_resumes_populates_entity_overlap(self, resume_folder):
+        screener = self._create_screener()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+
+        alice = next(r for r in ranked if r.reference_name == "alice_strong")
+        assert alice.entity_overlap > 0
+
+        carol = next(r for r in ranked if r.reference_name == "carol_weak")
+        assert carol.entity_overlap < alice.entity_overlap
+
+    def test_rank_resumes_populates_combined_score(self, resume_folder):
+        screener = self._create_screener()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        for r in ranked:
+            assert r.combined_score >= 0.0
+
+    def test_filter_after_ranking(self, resume_folder):
+        screener = self._create_screener()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        top2 = screener.filter_to_top_k(ranked, 2)
+        assert len(top2) == 2
+
+    def test_bm25_scoring_differentiates_resumes(self, resume_folder):
+        screener = self._create_screener()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+
+        alice = next(r for r in ranked if r.reference_name == "alice_strong")
+        carol = next(r for r in ranked if r.reference_name == "carol_weak")
+        assert alice.bm25_score > carol.bm25_score
+
+    def test_empty_folder_returns_empty(self, tmp_path):
+        folder = tmp_path / "empty"
+        folder.mkdir()
+        screener = self._create_screener()
+        ranked = screener.rank_resumes(self.JD_TEXT, folder)
+        assert ranked == []
+
+    def test_build_data_rows_after_ranking(self, resume_folder):
+        screener = self._create_screener()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        top2 = screener.filter_to_top_k(ranked, 2)
+        rows = screener.build_data_rows(top2)
+        assert len(rows) == 2
+        assert all("batch_name" in r for r in rows)
+        assert all("_documents" in r for r in rows)
+
+
+class TestResumePreScreenerIntegration:
+    """Integration-style tests with realistic embedding mock."""
+
+    JD_TEXT = (
+        "Senior Data Engineer\n\n"
+        "Requirements: Apache Spark, BigQuery, Python, SQL. "
+        "Google Cloud Platform and Docker required. "
+        "Kubernetes and Airflow preferred."
+    )
+
+    @pytest.fixture
+    def resume_folder(self, tmp_path: Path) -> Path:
+        folder = tmp_path / "resumes"
+        folder.mkdir()
+        (folder / "alice.txt").write_text(
+            "Alice Chen\nSenior Data Engineer\n"
+            "Skills: Apache Spark, BigQuery, Python, SQL, Docker, "
+            "Google Cloud Platform, Kubernetes, Airflow"
+        )
+        (folder / "bob.txt").write_text(
+            "Bob Jones\nBackend Developer\nSkills: Python, SQL, Docker, Kubernetes"
+        )
+        (folder / "carol.txt").write_text(
+            "Carol White\nFrontend Developer\nSkills: HTML, CSS, JavaScript, React"
+        )
+        return folder
+
+    def _create_screener_with_realistic_embeddings(self):
+        mock_emb = MagicMock()
+        dim = 8
+
+        def fake_embed(texts):
+            if isinstance(texts, str):
+                texts = [texts]
+            vectors = []
+            for text in texts:
+                if "Spark" in text and "BigQuery" in text:
+                    vectors.append([1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3])
+                elif "Python" in text:
+                    vectors.append([0.5, 0.4, 0.3, 0.2, 0.1, 0.1, 0.1, 0.1])
+                else:
+                    vectors.append([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
+            return vectors
+
+        mock_emb.embed.side_effect = fake_embed
+        mock_emb.embed_single.side_effect = lambda t: fake_embed([t])[0]
+        mock_emb.cosine_similarity = MagicMock(
+            side_effect=lambda a, b: (
+                sum(x * y for x, y in zip(a, b))
+                / (sum(x * x for x in a) ** 0.5 * sum(y * y for y in b) ** 0.5)
+            )
+        )
+
+        def _read_file(fp, rn, cn):
+            return Path(fp).read_text(encoding="utf-8")
+
+        with patch("src.orchestrator.pre_screener.FFEmbeddings", return_value=mock_emb):
+            with patch("src.orchestrator.pre_screener.DocumentProcessor") as MockDP:
+                mock_dp = MagicMock()
+                mock_dp.get_document_content.side_effect = _read_file
+                MockDP.return_value = mock_dp
+                screener = ResumePreScreener(embedding_model="mistral/mistral-embed")
+
+        screener._embeddings = mock_emb
+        screener._doc_processor = mock_dp
+        return screener
+
+    def test_alice_ranks_highest(self, resume_folder):
+        screener = self._create_screener_with_realistic_embeddings()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        assert ranked[0].reference_name == "alice"
+
+    def test_carol_ranks_lowest(self, resume_folder):
+        screener = self._create_screener_with_realistic_embeddings()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        assert ranked[-1].reference_name == "carol"
+
+    def test_entity_overlap_counts(self, resume_folder):
+        screener = self._create_screener_with_realistic_embeddings()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+
+        alice = next(r for r in ranked if r.reference_name == "alice")
+        carol = next(r for r in ranked if r.reference_name == "carol")
+        assert alice.entity_overlap >= 5
+        assert carol.entity_overlap <= 2
+
+    def test_full_pipeline_report(self, resume_folder):
+        screener = self._create_screener_with_realistic_embeddings()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+        top2 = screener.filter_to_top_k(ranked, 2)
+        report = screener.build_report(ranked, 2)
+
+        assert report["total_candidates"] == 3
+        assert report["top_k_selected"] == 2
+        assert len(report["selected_candidates"]) == 2
+        assert report["selected_candidates"][0]["common_name"] == "alice"
+
+    def test_combined_score_monotonic_with_relevance(self, resume_folder):
+        screener = self._create_screener_with_realistic_embeddings()
+        ranked = screener.rank_resumes(self.JD_TEXT, resume_folder)
+
+        scores = [r.combined_score for r in ranked]
+        for i in range(len(scores) - 1):
+            assert scores[i] >= scores[i + 1], (
+                f"Rank {i + 1} score {scores[i]} < rank {i + 2} score {scores[i + 1]}"
+            )
+
+
+class TestPreScreeningConfig:
+    """Tests for pre-screening configuration integration."""
+
+    def test_config_loads_defaults(self):
+        from src.config import get_config
+
+        config = get_config()
+        assert config.pre_screening.enabled is True
+        assert config.pre_screening.top_k == 20
+        assert config.pre_screening.bm25_weight == 0.3
+        assert config.pre_screening.embedding_weight == 0.7
+        assert config.pre_screening.embedding_model == "mistral/mistral-embed"
+
+    def test_config_embedding_cache_size(self):
+        from src.config import get_config
+
+        config = get_config()
+        assert config.pre_screening.embedding_cache_size == 512


### PR DESCRIPTION
## Summary

- Add embedding-based pre-screening (`ResumePreScreener`) with **BM25 hard exclusion gate**: candidates below keyword/overlap thresholds are removed entirely before expensive LLM evaluation
- Add `--pre-screen N` CLI flag to both manifest and workbook pipelines — requires explicit integer (no config default fallback)
- Write screening pipeline reports (`pre_screening_report.yaml`) with full ranking metrics; display summary in `run_orchestrator.py` and `manifest_run.py` output
- Remove `top_k` from config/`PreScreeningConfig` to prevent silent fallback; must be provided via CLI

## Commits (4)

| Commit | Description |
|--------|-------------|
| `ce09d0f` | feat: add embedding-based pre-screening for resume ranking |
| `4d9cf65` | feat: add --pre-screen to workbook pipeline, improve entity extraction |
| `b80e1c0` | feat: add screening pipeline metrics and tuning to bm25_min_overlap_ratio default |
| `2198b32` | fix: make BM25 a hard exclusion gate in pre-screening, remove top_k config default |

## Files changed (17)

- **Core**: `src/orchestrator/pre_screener.py` (663 lines, new), `src/config.py`, `config/main.yaml`
- **CLI scripts**: `create_screening_manifest.py`, `create_screening_workbook.py`, `manifest_run.py`, `run_orchestrator.py`
- **Shell**: `convenience/screening.sh`, `convenience/screening_manifest.sh`
- **Tests**: `tests/test_pre_screener.py` (574 lines, 39 tests)
- **Docs**: `AGENTS.md`, `MANIFEST_README.md`, `USE_CASES/resume_screening.md`, `docs/CONFIGURATION.md`, `docs/ORCHESTRATOR README.md`

## Testing

- 39 unit tests in `test_pre_screener.py` (all passing)
- End-to-end verified with `screening.sh` and `screening_manifest.sh` using `--pre-screen 1`
- Pre-commit hooks passed (1832 tests, ruff, ruff-format)