### PR TITLE
enh: Simplify pre-screening + add ABSOLUTE score anchoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ working_docs/*
 .coverage
 .opencode/package-lock.json
 articles/*
+*pre_screening_report.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -884,7 +884,7 @@ orchestrator.run()
 
 ### Pre-Screening (Cost Reduction)
 
-Embedding-based resume ranking filters candidates before the expensive LLM pipeline. Two-tier pipeline: Tier 1 is a **hard exclusion** gate using BM25 keyword matching — candidates below threshold are removed entirely. Tier 2 uses dense embedding cosine similarity to rank survivors, with scores combined using configurable weights (default 30/70 BM25/embedding).
+Embedding-based resume ranking filters candidates before the expensive LLM pipeline. Two-tier pipeline: Tier 1 is a **hard exclusion** gate using BM25 keyword matching — candidates below threshold are removed entirely. Tier 2 uses dense embedding cosine similarity to rank survivors. BM25 is used only as a hard filter; final ranking is determined entirely by embedding similarity.
 
 ```bash
 # Pre-screen top 20 resumes before LLM evaluation
@@ -903,8 +903,6 @@ python scripts/create_screening_manifest.py ./resumes/ --jd ./jd.md --pre-screen
 pre_screening:
   enabled: true
   embedding_model: "mistral/mistral-embed"
-  bm25_weight: 0.3
-  embedding_weight: 0.7
   bm25_min_score: 0.0
   bm25_min_overlap_ratio: 0.05
   embedding_cache_size: 512

--- a/USE_CASES/resume_screening.md
+++ b/USE_CASES/resume_screening.md
@@ -85,8 +85,8 @@ costs by only evaluating the top-N candidates instead of the full folder.
 Two-tier pipeline: Tier 1 is a **hard exclusion** gate using BM25 keyword
 matching on extracted named entities — candidates below the minimum score or
 overlap threshold are removed entirely. Tier 2 uses dense embedding cosine
-similarity to rank survivors, with BM25 and embedding scores combined using
-configurable weights (default 30/70 BM25/embedding).
+similarity to rank survivors. BM25 is used only as a hard filter; final
+ranking is determined entirely by embedding similarity.
 
 ```bash
 # Workbook: pre-screen top 20, bake filtered set into .xlsx
@@ -112,8 +112,6 @@ filtering by curating the folder contents before running.
 pre_screening:
   enabled: true
   embedding_model: "mistral/mistral-embed"
-  bm25_weight: 0.3
-  embedding_weight: 0.7
   bm25_min_score: 0.0
   bm25_min_overlap_ratio: 0.05
   embedding_cache_size: 512

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -270,8 +270,6 @@ observability:
 pre_screening:
   enabled: true
   embedding_model: "mistral/mistral-embed"
-  bm25_weight: 0.3
-  embedding_weight: 0.7
   bm25_min_score: 0.0
   bm25_min_overlap_ratio: 0.05
   embedding_cache_size: 512

--- a/config/prompts/screening_planning.yaml
+++ b/config/prompts/screening_planning.yaml
@@ -39,6 +39,18 @@ prompts:
            is the criteria_name (matching exactly) with an integer score 1-10, plus a
            'reasoning' key. Example for a criterion named 'skills_match':
            {"skills_match": 8, "reasoning": "..."}
+         - Include an ABSOLUTE scoring scale with concrete descriptions for each
+           score band (1-2, 3-4, 5-6, 7-8, 9-10) so the evaluator applies the
+           scale consistently across ALL candidates. Example for a "python" criterion:
+
+           1-2: No Python experience — no evidence of Python in the resume.
+           3-4: Minimal — mentions Python but no evidence of professional use.
+           5-6: Intermediate — has used Python professionally but gaps exist.
+           7-8: Strong — proficient with evidence of substantive professional use.
+           9-10: Expert — deep mastery with advanced use or mentorship evidence.
+
+           Include the instruction: "Use this ABSOLUTE scale — apply it consistently
+           across ALL candidates."
 
       Return your response as JSON with exactly two keys:
       - "scoring_criteria": array of criteria objects
@@ -64,6 +76,12 @@ prompts:
       Refine them for:
       - Clarity: each prompt should be unambiguous about what to evaluate
       - Consistency: all prompts should use the same scoring scale and JSON format
+      - Score anchoring: every evaluation prompt MUST include an ABSOLUTE scoring scale
+        with concrete descriptions for each band (1-2, 3-4, 5-6, 7-8, 9-10) so the
+        evaluator applies the scale consistently across ALL candidates. Each band must
+        describe what EVIDENCE qualifies a candidate for that score level. Include the
+        instruction: "Use this ABSOLUTE scale — apply it consistently across ALL
+        candidates." Verify every prompt has this scale; add it to any that are missing.
       - Reliability: prompts should elicit scores that are reproducible
       - Completeness: ensure all important aspects of the JD are covered
       - Weight balance: weights should reflect the JD's priorities

--- a/config/prompts/screening_skills_planning.yaml
+++ b/config/prompts/screening_skills_planning.yaml
@@ -104,7 +104,7 @@ prompts:
       CRITICAL RULES:
       - One skill per criterion. Never combine multiple skills into one.
       - Every criterion MUST include weight as a float between 0.3 and 2.0.
-      - Every criterion MUST include label_1 set to one of: technical,
+      - Every criterion MUST have label_1 set to one of: technical,
         education, experience, or domain.
       - Each source_prompt must exactly match a prompt_name in the prompts array.
       - Each prompt text MUST explicitly state the exact JSON key the evaluator
@@ -113,6 +113,17 @@ prompts:
         NOT a nested object. Correct: {"python": 8}. Wrong: {"python": {"score": 8}}.
       - The prompt text for each skill must be specific about what evidence to
         look for (e.g., for "python": look for projects, years used, libraries).
+      - SCORE ANCHORING: Every generated evaluation prompt MUST include an ABSOLUTE
+        scoring scale with concrete descriptions for each band (1-2, 3-4, 5-6, 7-8,
+        9-10) describing what EVIDENCE qualifies a candidate for that level. Include
+        the instruction: "Use this ABSOLUTE scale — apply it consistently across ALL
+        candidates." Example for "python":
+
+        1-2: No Python experience — no evidence of Python in the resume.
+        3-4: Minimal — mentions Python but no evidence of professional use.
+        5-6: Intermediate — has used Python professionally but gaps exist.
+        7-8: Strong — proficient with evidence of substantive professional use.
+        9-10: Expert — deep mastery with advanced use or mentorship evidence.
     references: '["job_description"]'
     notes: >
       Master generator: exhaustively extracts every skill/requirement from JD,
@@ -131,6 +142,12 @@ prompts:
         unless the JD treats them as one)
       - Clarity: each prompt should precisely define what evidence demonstrates
         proficiency at each score level (1-10)
+      - Score anchoring: EVERY evaluation prompt MUST include an ABSOLUTE scoring scale
+        with concrete descriptions for each band (1-2, 3-4, 5-6, 7-8, 9-10) describing
+        what EVIDENCE qualifies a candidate for that score level. Include the instruction:
+        "Use this ABSOLUTE scale — apply it consistently across ALL candidates." Verify
+        every prompt has this scale; add it to any that are missing. The scale descriptions
+        must be specific to the skill being evaluated, not generic.
       - Weight calibration: EVERY criterion MUST have a weight field (float
         0.3–2.0). Weights should reflect the JD's actual emphasis. Skills
         mentioned in the first paragraph or in a "Required" section should be

--- a/config/prompts/screening_static.yaml
+++ b/config/prompts/screening_static.yaml
@@ -55,25 +55,67 @@ prompts:
     prompt_name: evaluate_skills
     prompt: |
       Evaluate {{candidate_name}}'s technical skills against the job description.
-      For each required skill, rate proficiency (1-10). Return JSON:
-      {"skills_match": <1-10>, "reasoning": "..."}
+
+      Use this ABSOLUTE scale — apply it consistently across ALL candidates regardless
+      of how impressive any single resume appears in isolation:
+
+      1-2: No relevant skills — none of the required skills appear in the resume.
+      3-4: Minimal — mentions some required skills but no evidence of professional use.
+      5-6: Intermediate — has used most required skills in professional settings, but
+          gaps exist or depth is shallow.
+      7-8: Strong — proficient in all required skills with evidence of substantive
+          professional use; minor gaps in secondary skills only.
+      9-10: Expert — deep mastery of all required skills; evidence of advanced use,
+          mentorship, architecture-level decisions, or recognized expertise.
+
+      Do not inflate scores for candidates who are strong in unrelated areas.
+      A candidate with no exposure to the required stack should score 1-4 regardless
+      of other strengths.
+
+      Return JSON: {"skills_match": <1-10>, "reasoning": "..."}
     history: '["extract_profile"]'
     references: '["job_description"]'
 
   - sequence: 30
     prompt_name: evaluate_education
     prompt: |
-      Evaluate {{candidate_name}}'s education quality and relevance.
-      Consider institution reputation, degree relevance. Return JSON:
-      {"education": <1-10>, "reasoning": "..."}
+      Evaluate {{candidate_name}}'s education quality and relevance to the role.
+
+      Use this ABSOLUTE scale — apply it consistently across ALL candidates:
+
+      1-2: No relevant education — no degree or degree in an unrelated field.
+      3-4: Below average — degree in a related field but from an unremarkable institution
+          with no academic distinction.
+      5-6: Adequate — relevant degree from a solid institution; meets the baseline
+          educational requirement for the role.
+      7-8: Strong — degree from a well-regarded institution, strong academic performance,
+          or advanced degree (Masters/PhD) directly relevant to the role.
+      9-10: Exceptional — degree from a top-tier institution, outstanding academic
+          achievements, published research, or highly specialized advanced degree.
+
+      Return JSON: {"education": <1-10>, "reasoning": "..."}
     history: '["extract_profile"]'
     references: '["job_description"]'
 
   - sequence: 40
     prompt_name: evaluate_experience
     prompt: |
-      Evaluate {{candidate_name}}'s work experience depth and relevance.
-      Consider years, progression, scope, relevance.
+      Evaluate {{candidate_name}}'s work experience depth and relevance to the role.
+
+      Use this ABSOLUTE scale — apply it consistently across ALL candidates:
+
+      1-2: No relevant experience — has never worked in a related role or industry.
+      3-4: Junior — less than half the required years, or experience is tangential
+          with limited transferable responsibilities.
+      5-6: Intermediate — meets the minimum years requirement but with limited scope,
+          no progression, or mixed relevance.
+      7-8: Strong — exceeds the minimum years with clear progression in responsibility,
+          scope, and relevance to the target role.
+      9-10: Exceptional — extensive deeply relevant experience with leadership,
+          strategic impact, and a clear track record of increasingly significant
+          accomplishments in the domain.
+
+      Consider years, progression, scope, and relevance.
       Return JSON: {"experience_depth": <1-10>, "reasoning": "..."}
     history: '["extract_profile"]'
     references: '["job_description"]'
@@ -81,8 +123,24 @@ prompts:
   - sequence: 50
     prompt_name: evaluate_growth
     prompt: |
-      Assess {{candidate_name}}'s growth trajectory. Look for increasing responsibility,
-      career progression, skill development, learning agility.
+      Assess {{candidate_name}}'s career growth trajectory and learning agility.
+
+      Use this ABSOLUTE scale — apply it consistently across ALL candidates:
+
+      1-2: Stagnant — same role/level for many years with no evidence of new skills
+          or increasing responsibility.
+      3-4: Slow — minimal progression over time; lateral moves without clear growth;
+          limited evidence of skill development.
+      5-6: Steady — reasonable progression with some increases in responsibility;
+          evidence of learning new skills but at a moderate pace.
+      7-8: Strong — clear upward trajectory with regular promotions or expanding scope;
+          proactive skill development; takes on increasing responsibility.
+      9-10: Exceptional — rapid acceleration through roles; demonstrates learning
+          agility across domains; evidence of leadership emergence and
+          self-directed growth.
+
+      Look for increasing responsibility, career progression, skill development,
+      and learning agility.
       Return JSON: {"growth_trajectory": <1-10>, "evidence": ["..."], "reasoning": "..."}
     history: '["extract_profile"]'
 
@@ -90,7 +148,21 @@ prompts:
     prompt_name: evaluate_employers
     prompt: |
       Evaluate the quality and relevance of {{candidate_name}}'s past employers.
-      Consider company reputation, industry alignment, scale, competitiveness.
+
+      Use this ABSOLUTE scale — apply it consistently across ALL candidates:
+
+      1-2: No relevant employers — all experience is at small or unknown companies
+          in unrelated industries with no name recognition.
+      3-4: Below average — mostly small companies or unknown firms; limited industry
+          alignment with the target role.
+      5-6: Adequate — mix of mid-tier companies with some industry relevance;
+          employers are recognizable within their niche.
+      7-8: Strong — experience at well-known companies in the relevant industry;
+          employers are respected and competitive; good industry alignment.
+      9-10: Exceptional — experience at top-tier, highly selective employers (FAANG,
+          Fortune 100, industry leaders) directly relevant to the target domain.
+
+      Consider company reputation, industry alignment, scale, and competitiveness.
       Return JSON: {"employer_prestige": <1-10>, "reasoning": "..."}
     history: '["extract_profile"]'
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -390,8 +390,6 @@ resumes down to a top-K subset before the expensive LLM evaluation phase.
 pre_screening:
   enabled: true
   embedding_model: "mistral/mistral-embed"
-  bm25_weight: 0.3
-  embedding_weight: 0.7
   bm25_min_score: 0.0
   bm25_min_overlap_ratio: 0.05
   embedding_cache_size: 512
@@ -401,8 +399,6 @@ pre_screening:
 |---------|---------|-------------|
 | `enabled` | `true` | Enable pre-screening |
 | `embedding_model` | `mistral/mistral-embed` | LiteLLM model string for embeddings |
-| `bm25_weight` | `0.3` | Weight for BM25 score in combined ranking of survivors |
-| `embedding_weight` | `0.7` | Weight for embedding similarity in combined ranking of survivors |
 | `bm25_min_score` | `0.0` | Minimum BM25 score — candidates below are excluded (hard gate) |
 | `bm25_min_overlap_ratio` | `0.05` | Minimum entity overlap ratio — candidates below are excluded (hard gate) |
 | `embedding_cache_size` | `512` | LRU cache size for embedding lookups |
@@ -410,8 +406,8 @@ pre_screening:
 Two-tier pipeline: Tier 1 is a **hard exclusion** gate using BM25 keyword
 matching on extracted named entities — candidates below `bm25_min_score` or
 `bm25_min_overlap_ratio` are removed entirely. Tier 2 uses dense embedding
-cosine similarity to rank survivors, with scores combined using configurable
-weights. Specify the number of candidates to keep via CLI:
+cosine similarity to rank survivors. BM25 is used only as a hard filter;
+final ranking is determined entirely by embedding similarity.
 `--pre-screen 10` (required, no config default).
 
 ### Model Defaults (`model_defaults.yaml`)

--- a/scripts/create_screening_manifest.py
+++ b/scripts/create_screening_manifest.py
@@ -402,17 +402,11 @@ def main() -> int:
             top_k = args.pre_screen
             print(f"\n  Pre-screening enabled (top-{top_k} of {resume_count})")
             print(f"  Embedding model: {config.pre_screening.embedding_model}")
-            print(
-                f"  Weights: BM25={config.pre_screening.bm25_weight}, "
-                f"embedding={config.pre_screening.embedding_weight}"
-            )
 
             jd_text = Path(args.jd).read_text(encoding="utf-8")
 
             pre_screener = ResumePreScreener(
                 embedding_model=config.pre_screening.embedding_model,
-                bm25_weight=config.pre_screening.bm25_weight,
-                embedding_weight=config.pre_screening.embedding_weight,
                 bm25_min_score=config.pre_screening.bm25_min_score,
                 bm25_min_overlap_ratio=config.pre_screening.bm25_min_overlap_ratio,
                 embedding_cache_size=config.pre_screening.embedding_cache_size,

--- a/scripts/create_screening_workbook.py
+++ b/scripts/create_screening_workbook.py
@@ -242,10 +242,6 @@ def main() -> int:
             top_k = args.pre_screen
             print(f"\n  Pre-screening enabled (top-{top_k} of {len(resume_docs)})")
             print(f"  Embedding model: {config.pre_screening.embedding_model}")
-            print(
-                f"  Weights: BM25={config.pre_screening.bm25_weight}, "
-                f"embedding={config.pre_screening.embedding_weight}"
-            )
 
             from pathlib import Path
 
@@ -253,8 +249,6 @@ def main() -> int:
 
             pre_screener = ResumePreScreener(
                 embedding_model=config.pre_screening.embedding_model,
-                bm25_weight=config.pre_screening.bm25_weight,
-                embedding_weight=config.pre_screening.embedding_weight,
                 bm25_min_score=config.pre_screening.bm25_min_score,
                 bm25_min_overlap_ratio=config.pre_screening.bm25_min_overlap_ratio,
                 embedding_cache_size=config.pre_screening.embedding_cache_size,

--- a/scripts/sample_workbooks/screening.py
+++ b/scripts/sample_workbooks/screening.py
@@ -85,9 +85,18 @@ def get_static_screening_prompts(
         PromptSpec(
             20,
             "evaluate_skills",
-            "Evaluate {{candidate_name}}'s technical skills against the job description. "
-            "For each required skill, rate proficiency (1-10). Return JSON: "
-            '{"skills_match": <1-10>, "reasoning": "..."}',
+            "Evaluate {{candidate_name}}'s technical skills against the job description.\n"
+            "\n"
+            "Use this ABSOLUTE scale — apply it consistently across ALL candidates:\n"
+            "\n"
+            "1-2: No relevant skills — none of the required skills appear.\n"
+            "3-4: Minimal — mentions some required skills but no evidence of professional use.\n"
+            "5-6: Intermediate — has used most required skills professionally, but gaps exist.\n"
+            "7-8: Strong — proficient in all required skills with substantive professional use.\n"
+            "9-10: Expert — deep mastery with advanced use, mentorship, or architecture evidence.\n"
+            "\n"
+            "Do not inflate scores for candidates strong in unrelated areas.\n"
+            'Return JSON: {"skills_match": <1-10>, "reasoning": "..."}',
             history='["extract_profile"]',
             references='["job_description"]',
         )
@@ -96,9 +105,18 @@ def get_static_screening_prompts(
         PromptSpec(
             30,
             "evaluate_education",
-            "Evaluate {{candidate_name}}'s education quality and relevance. "
-            "Consider institution reputation, degree relevance. Return JSON: "
-            '{"education": <1-10>, "reasoning": "..."}',
+            "Evaluate {{candidate_name}}'s education quality and relevance.\n"
+            "\n"
+            "Use this ABSOLUTE scale — apply it consistently across ALL candidates:\n"
+            "\n"
+            "1-2: No relevant education — no degree or unrelated field.\n"
+            "3-4: Below average — related field but unremarkable institution.\n"
+            "5-6: Adequate — relevant degree from a solid institution; meets baseline.\n"
+            "7-8: Strong — well-regarded institution, advanced degree, or strong performance.\n"
+            "9-10: Exceptional — top-tier institution, published research, or specialized degree.\n"
+            "\n"
+            "Consider institution reputation and degree relevance. "
+            'Return JSON: {"education": <1-10>, "reasoning": "..."}',
             history='["extract_profile"]',
             references='["job_description"]',
         )
@@ -107,7 +125,16 @@ def get_static_screening_prompts(
         PromptSpec(
             40,
             "evaluate_experience",
-            "Evaluate {{candidate_name}}'s work experience depth and relevance. "
+            "Evaluate {{candidate_name}}'s work experience depth and relevance.\n"
+            "\n"
+            "Use this ABSOLUTE scale — apply it consistently across ALL candidates:\n"
+            "\n"
+            "1-2: No relevant experience — never worked in a related role or industry.\n"
+            "3-4: Junior — less than half the required years or tangential experience.\n"
+            "5-6: Intermediate — meets minimum years but limited scope or progression.\n"
+            "7-8: Strong — exceeds minimum years with clear progression and relevance.\n"
+            "9-10: Exceptional — extensive deeply relevant experience with leadership impact.\n"
+            "\n"
             "Consider years, progression, scope, relevance. "
             'Return JSON: {"experience_depth": <1-10>, "reasoning": "..."}',
             history='["extract_profile"]',
@@ -118,8 +145,18 @@ def get_static_screening_prompts(
         PromptSpec(
             50,
             "evaluate_growth",
-            "Assess {{candidate_name}}'s growth trajectory. Look for increasing responsibility, "
-            "career progression, skill development, learning agility. "
+            "Assess {{candidate_name}}'s career growth trajectory.\n"
+            "\n"
+            "Use this ABSOLUTE scale — apply it consistently across ALL candidates:\n"
+            "\n"
+            "1-2: Stagnant — same role/level for years with no new skills.\n"
+            "3-4: Slow — minimal progression; lateral moves; limited skill development.\n"
+            "5-6: Steady — reasonable progression with some increasing responsibility.\n"
+            "7-8: Strong — clear upward trajectory with regular promotions and skill growth.\n"
+            "9-10: Exceptional — rapid acceleration; learning agility across domains.\n"
+            "\n"
+            "Look for increasing responsibility, career progression, skill development, "
+            "learning agility. "
             'Return JSON: {"growth_trajectory": <1-10>, "evidence": ["..."], "reasoning": "..."}',
             history='["extract_profile"]',
         )
@@ -128,7 +165,16 @@ def get_static_screening_prompts(
         PromptSpec(
             60,
             "evaluate_employers",
-            "Evaluate the quality and relevance of {{candidate_name}}'s past employers. "
+            "Evaluate the quality and relevance of {{candidate_name}}'s past employers.\n"
+            "\n"
+            "Use this ABSOLUTE scale — apply it consistently across ALL candidates:\n"
+            "\n"
+            "1-2: No relevant employers — all experience at unknown companies in unrelated fields.\n"
+            "3-4: Below average — mostly small/unknown firms with limited industry alignment.\n"
+            "5-6: Adequate — mid-tier companies with some industry relevance.\n"
+            "7-8: Strong — well-known companies in the relevant industry.\n"
+            "9-10: Exceptional — top-tier, highly selective employers directly relevant.\n"
+            "\n"
             "Consider company reputation, industry alignment, scale, competitiveness. "
             'Return JSON: {"employer_prestige": <1-10>, "reasoning": "..."}',
             history='["extract_profile"]',
@@ -194,6 +240,10 @@ def get_planning_screening_prompts(
             "is the criteria_name (matching exactly) with an integer score 1-10, plus a "
             "'reasoning' key. Example for a criterion named 'skills_match': "
             '{"skills_match": 8, "reasoning": "..."}\n'
+            "   - Include an ABSOLUTE scoring scale with concrete descriptions for each "
+            "score band (1-2, 3-4, 5-6, 7-8, 9-10) so the evaluator applies the scale "
+            "consistently across ALL candidates. Include the instruction: \"Use this "
+            "ABSOLUTE scale — apply it consistently across ALL candidates.\"\n"
             "\n"
             "Return your response as JSON with exactly two keys:\n"
             '- "scoring_criteria": array of criteria objects\n'
@@ -220,6 +270,10 @@ def get_planning_screening_prompts(
             "Refine them for:\n"
             "- Clarity: each prompt should be unambiguous about what to evaluate\n"
             "- Consistency: all prompts should use the same scoring scale and JSON format\n"
+            "- Score anchoring: every evaluation prompt MUST include an ABSOLUTE scoring "
+            "scale with concrete descriptions for each band (1-2, 3-4, 5-6, 7-8, 9-10) "
+            "so the evaluator applies the scale consistently across ALL candidates. "
+            "Verify every prompt has this scale; add it to any that are missing.\n"
             "- Reliability: prompts should elicit scores that are reproducible\n"
             "- Completeness: ensure all important aspects of the JD are covered\n"
             "- Weight balance: weights should reflect the JD's priorities\n"

--- a/src/config.py
+++ b/src/config.py
@@ -495,8 +495,6 @@ class PreScreeningConfig(BaseSettings):
 
     enabled: bool = True
     embedding_model: str = "mistral/mistral-embed"
-    bm25_weight: float = 0.3
-    embedding_weight: float = 0.7
     bm25_min_score: float = 0.0
     bm25_min_overlap_ratio: float = 0.05
     embedding_cache_size: int = 512

--- a/src/orchestrator/pre_screener.py
+++ b/src/orchestrator/pre_screener.py
@@ -234,13 +234,14 @@ class ResumePreScreener:
     computes dense embedding similarity between the JD and each surviving
     resume for precise semantic ranking.
 
+    BM25 is used only as a hard exclusion filter in Tier 1. Final ranking
+    is determined entirely by embedding cosine similarity (Tier 2).
+
     Args:
         embedding_model: LiteLLM model string (e.g., ``"mistral/mistral-embed"``).
         cache_dir: Directory for parsed document cache.
         bm25_min_score: Minimum BM25 score to pass tier 1 filter.
         bm25_min_overlap_ratio: Minimum fraction of JD entities that must appear.
-        bm25_weight: Weight for BM25 score in combined ranking (0-1).
-        embedding_weight: Weight for embedding score in combined ranking (0-1).
         embedding_cache_size: LRU cache size for embedding model.
 
     """
@@ -251,16 +252,12 @@ class ResumePreScreener:
         cache_dir: str | None = None,
         bm25_min_score: float = 0.0,
         bm25_min_overlap_ratio: float = 0.0,
-        bm25_weight: float = 0.3,
-        embedding_weight: float = 0.7,
         embedding_cache_size: int = 512,
     ) -> None:
         config = get_config()
         self._cache_dir = cache_dir or config.paths.ffai_data
         self._bm25_min_score = bm25_min_score
         self._bm25_min_overlap_ratio = bm25_min_overlap_ratio
-        self._bm25_weight = bm25_weight
-        self._embedding_weight = embedding_weight
 
         self._embeddings = FFEmbeddings(
             model=embedding_model,
@@ -273,7 +270,7 @@ class ResumePreScreener:
 
         logger.info(
             f"ResumePreScreener initialized: model={embedding_model}, "
-            f"bm25_weight={bm25_weight}, embedding_weight={embedding_weight}"
+            f"bm25_min_overlap_ratio={bm25_min_overlap_ratio}"
         )
 
     def rank_resumes(
@@ -634,30 +631,19 @@ class ResumePreScreener:
         return all_embeddings
 
     def _combine_scores(self, resumes: list[RankedResume]) -> list[RankedResume]:
-        """Compute combined score from BM25 and embedding scores.
+        """Set combined score to embedding cosine similarity.
 
-        Uses configured weights to produce a single combined score for each
-        resume. All resumes in the list have passed the BM25 hard filter.
+        BM25 is used only as a hard filter in Tier 1. The final ranking
+        is determined entirely by the embedding similarity score.
 
         Args:
-            resumes: RankedResume list with both scores populated.
+            resumes: RankedResume list with embedding scores populated.
 
         Returns:
-            Same list with combined_score populated.
+            Same list with combined_score set to embedding_score.
 
         """
-        if not resumes:
-            return resumes
-
-        bm25_scores = [r.bm25_score for r in resumes]
-        emb_scores = [r.embedding_score for r in resumes]
-
-        max_bm25 = max(bm25_scores) if bm25_scores and max(bm25_scores) > 0 else 1.0
-        max_emb = max(emb_scores) if emb_scores and max(emb_scores) > 0 else 1.0
-
         for r in resumes:
-            norm_bm25 = r.bm25_score / max_bm25
-            norm_emb = r.embedding_score / max_emb
-            r.combined_score = self._bm25_weight * norm_bm25 + self._embedding_weight * norm_emb
+            r.combined_score = r.embedding_score
 
         return resumes

--- a/tests/test_pre_screener.py
+++ b/tests/test_pre_screener.py
@@ -562,8 +562,6 @@ class TestPreScreeningConfig:
 
         config = get_config()
         assert config.pre_screening.enabled is True
-        assert config.pre_screening.bm25_weight == 0.3
-        assert config.pre_screening.embedding_weight == 0.7
         assert config.pre_screening.embedding_model == "mistral/mistral-embed"
         assert config.pre_screening.bm25_min_overlap_ratio == 0.05
 


### PR DESCRIPTION
## Summary

This PR introduces two key improvements to the resume screening pipeline:

### 1. Simplified Pre-screening Architecture (7169595)
- **Refactor**: Removed weighted hybrid scoring (BM25 + embedding) in favor of clean two-tier pipeline
- **Tier 1**: BM25 used **only as hard exclusion filter** (entity overlap check)
- **Tier 2**: Final ranking determined **entirely by embedding cosine similarity**
- **Rationale**: Embedding models capture semantic fit better than BM25 for ranking; the weighted combination added complexity without clear benefit. BM25 remains valuable as a cheap CPU-based filter to exclude obviously irrelevant resumes.
- **Impact**: Removed 2 hyperparameters (, ), clearer semantics, easier to maintain

### 2. ABSOLUTE Score Band Anchoring (c082858)
- **Feature**: Added explicit 5-band score scales (1-2, 3-4, 5-6, 7-8, 9-10) with concrete evidence-based descriptions
- **Problem solved**: Addresses LLM score anchoring bias where models adjust their scale per-candidate instead of applying consistent absolute standards
- **Files updated**:
  -  - anchors on all 5 evaluation prompts
  -  - anchoring instruction in analyze_jd and refine_criteria
  -  - anchoring in analyze_jd critical rules + refine_criteria
  -  - matching anchors in hardcoded fallback prompts

## Testing
- Pre-screening logic validated in 
- Prompt templates updated across all screening workflows

## Breaking Changes
None - the changes are backward compatible. The pre-screening simplification maintains the same filtering behavior (BM25 hard gate) while improving ranking clarity.