### PR TITLE
feat: add Sphinx documentation generation with autodoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.parquet
 ffclients.egg-info/*
+Plico.egg-info/*
+docs/sphinx/
+docs/source/src*
 .vscode/settings.json
 __pycache__/
 *.pyc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,57 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+
+# Add the project root and src to Python path so autodoc can import modules
+# The project uses src/ as a package directory
+project_root = os.path.abspath("../..")
+sys.path.insert(0, project_root)
+sys.path.insert(0, os.path.join(project_root, "src"))
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "Plico"
+copyright = "2025, Antonio Quinonez / Far Finer LLC"
+author = "Antonio Quinonez / Far Finer LLC"
+release = "0.1.0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# Napoleon settings (for Google-style docstrings)
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]
+
+# Autodoc settings
+autoclass_content = "both"
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "special-members": "__init__",
+    "undoc-members": True,
+    "exclude-members": "__weakref__",
+}
+
+# Master document
+master_doc = "index"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,30 @@
+Plico Documentation
+===================
+
+Welcome to the Plico documentation!
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference:
+   :glob:
+
+   src.FFAI
+   src.FFAIClientBase
+   src.config
+   src.ConversationHistory
+   src.OrderedPromptHistory
+   src.PermanentHistory
+   src.prompt_templates
+   src.Clients
+   src.core
+   src.observability
+   src.orchestrator
+   src.RAG
+   src.agent
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "ffclients"
+name = "Plico"
 version = "0.1.0"
 description = "Declarative AI orchestration — one manifest protocol, three authoring paths"
 readme = "README.md"

--- a/tasks.py
+++ b/tasks.py
@@ -327,6 +327,55 @@ def test_all(c: Context):
 
 
 @task
+def docs_sphinx(c: Context, clean: bool = False, apidoc: bool = True):
+    """Build Sphinx documentation in HTML, text, and JSON formats.
+
+    Outputs are written to:
+        docs/sphinx/html/  - HTML documentation
+        docs/sphinx/text/  - Plain text documentation
+        docs/sphinx/json/  - JSON documentation
+
+    Args:
+        clean: Remove existing build directories before building.
+        apidoc: Run sphinx-apidoc to generate .rst files from Python modules.
+
+    Examples:
+        inv docs-sphinx              # Build all formats (with apidoc)
+        inv docs-sphinx --clean      # Clean and rebuild all formats
+        inv docs-sphinx --no-apidoc  # Skip apidoc, use existing .rst files
+    """
+    source_dir = "docs/source"
+    base_out = "docs/sphinx"
+
+    if apidoc:
+        print("Generating API documentation stubs with sphinx-apidoc...")
+        c.run(f"sphinx-apidoc -o {source_dir}/ src/ --force --separate", pty=PTY)
+
+    if clean:
+        print("Cleaning existing build directories...")
+        for builder in ["html", "text", "json"]:
+            out_dir = f"{base_out}/{builder}"
+            if os.path.exists(out_dir):
+                import shutil
+
+                shutil.rmtree(out_dir)
+                print(f"  Removed {out_dir}")
+
+    builders = [
+        ("html", f"{base_out}/html"),
+        ("text", f"{base_out}/text"),
+        ("json", f"{base_out}/json"),
+    ]
+
+    print("Building Sphinx documentation...")
+    for builder, out_dir in builders:
+        print(f"  Building {builder} -> {out_dir}")
+        c.run(f"sphinx-build -b {builder} {source_dir} {out_dir}", pty=PTY)
+
+    print("\nSphinx documentation built successfully!")
+
+
+@task
 def explain(c: Context, workbook: str, concurrency: str = "1"):
     """Show execution plan for a workbook without running it.
 
@@ -1284,6 +1333,7 @@ ns.add_task(lint)
 ns.add_task(format)
 ns.add_task(test)
 ns.add_task(test_all, name="test-all")
+ns.add_task(docs_sphinx, name="docs-sphinx")
 ns.add_collection(wb, name="wb")
 ns.add_collection(rag, name="rag")
 ns.add_collection(screening, name="screening")


### PR DESCRIPTION
Add comprehensive Sphinx documentation generation:

- Configure Sphinx with autodoc, viewcode, and napoleon extensions
- Generate API documentation for all Plico modules (classes and methods)
- Add invoke task 'docs-sphinx' to build HTML, text, and JSON formats
- Update .gitignore to exclude generated docs, .rst stubs, and egg-info
- Update pyproject.toml with Plico project name

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>